### PR TITLE
Fix camera device handling

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -10,10 +10,18 @@ pub struct Camera {
 
 impl Camera {
     pub fn new(device: &str) -> Result<Self, Box<dyn Error>> {
-        let capture = videoio::VideoCapture::new(device.parse::<i32>()?, videoio::CAP_ANY)?;
+        // `device` may be a numeric index ("0") or a path like "/dev/video0".
+        // Try parsing as an index first, otherwise fall back to opening by path.
+        let capture = if let Ok(index) = device.parse::<i32>() {
+            videoio::VideoCapture::new(index, videoio::CAP_ANY)?
+        } else {
+            videoio::VideoCapture::from_file(device, videoio::CAP_ANY)?
+        };
+
         if !capture.is_opened()? {
             return Err("Failed to open camera".into());
         }
+
         Ok(Camera { capture })
     }
 


### PR DESCRIPTION
## Summary
- allow camera initialization via device path

## Testing
- `cargo fmt` *(fails: component not installed)*
- `cargo test --all --quiet` *(fails: could not download crates)*