### PR TITLE
Add config loading integration test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,0 +1,8 @@
+use rustspray::config::Config;
+
+#[test]
+fn load_config_values() {
+    let cfg = Config::load("config/Config.toml").expect("load config");
+    assert_eq!(cfg.camera.device, "/dev/video2");
+    assert_eq!(cfg.spray.pins[0], 23);
+}


### PR DESCRIPTION
## Summary
- expose config as a library module
- add `tests/config_tests.rs` to check `Config::load`

## Testing
- `cargo test --no-run --target x86_64-unknown-linux-gnu` *(fails: Could not connect to crates.io)*