### PR TITLE
Fix apt repo injection for RaspberryPi builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,19 +97,19 @@ jobs:
           # Add ports.ubuntu.com lines
           CODENAME=$(lsb_release -cs)
           if [ "${{ matrix.platform.os_name }}" = "RaspberryPi-armv7" ]; then
-            sudo bash -c "cat >/etc/apt/sources.list.d/ports-armhf.list <<'EOF'
-            deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME main restricted universe multiverse
-            deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME-updates main restricted universe multiverse
-            deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME-security main restricted universe multiverse
-            deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME-backports main restricted universe multiverse
-            EOF"
+            cat <<EOF | sudo tee /etc/apt/sources.list.d/ports-armhf.list
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME main restricted universe multiverse
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME-updates main restricted universe multiverse
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME-security main restricted universe multiverse
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $CODENAME-backports main restricted universe multiverse
+EOF
           else
-            sudo bash -c "cat >/etc/apt/sources.list.d/ports-arm64.list <<'EOF'
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME-updates main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME-security main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME-backports main restricted universe multiverse
-            EOF"
+            cat <<EOF | sudo tee /etc/apt/sources.list.d/ports-arm64.list
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $CODENAME-backports main restricted universe multiverse
+EOF
           fi
 
           sudo apt-get update -y


### PR DESCRIPTION
## Summary
- fix quoting in RaspberryPi steps of CI workflow so apt repo file is written correctly

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*