### PR TITLE
Add optional Raspberry Pi camera support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ thiserror  = "1.0"
 
 # Raspberry Pi GPIO support (enabled only on ARM platforms)
 rppal = { version = "0.15", optional = true }
+# Raspberry Pi camera (V4L2)
+rscam = { version = "0.5", optional = true }
 
 # ─────────────────────────────────────────────────────────────────────────────
 [features]
@@ -42,6 +44,7 @@ rppal = { version = "0.15", optional = true }
 # GPIO enabled by default (for ARM targets like Raspberry Pi)
 default    = ["with-rppal"]
 with-rppal = ["rppal"]
+picam      = ["rscam"]
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Platform guard: only include `rppal` on ARM and AARCH64 targets

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Rust-Spray is implemented as a set of cooperative asynchronous tasks orchestrate
 - **Flow Sensor:** DigiFlow 200 for closed-loop flow control.  
 - **GPS Receiver:** u-blox F9P (RTK), typical 10+ Hz update rate.  
 - **Camera (Optional):** Pi HQ Camera v2 or USB camera for OpenCV processing.
+  Enable the `picam` Cargo feature and set `camera.use_rpi_cam = true` to use the Pi camera module.
 
 Refer to the project wiki for wiring diagrams and recommended peripherals.
 
@@ -165,6 +166,7 @@ hardware. The sample file looks like this:
 device = "/dev/video2"
 resolution_width = 1280
 resolution_height = 720
+use_rpi_cam = false
 
 [detection]
 algorithm = "hsv"
@@ -185,6 +187,7 @@ activation_duration_ms = 200
 ```
 
 - `camera.device` is the path to the video capture device.
+- `camera.use_rpi_cam` enables the Raspberry Pi camera driver when set to `true`.
 - `detection.algorithm` can be `"exg"` or `"hsv"`.
 - `spray.pins` lists the GPIO pins used to drive the sprayers.
 

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -10,6 +10,8 @@ device = "/dev/video2"
 # Higher resolutions (e.g., 1280x720) improve detection but may slow performance
 resolution_width = 1280
 resolution_height = 720
+# Use the Raspberry Pi camera driver (true/false)
+use_rpi_cam = false
 
 # Detection settings
 [detection]

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,14 +4,34 @@ use opencv::{
 };
 use std::error::Error;
 
+#[cfg(feature = "picam")]
+mod picam;
+
+pub enum CameraBackend {
+    OpenCv(VideoCapture),
+    #[cfg(feature = "picam")]
+    Pi(picam::Picam),
+}
+
 pub struct Camera {
-    capture: VideoCapture,
+    backend: CameraBackend,
 }
 
 impl Camera {
-    pub fn new(device: &str) -> Result<Self, Box<dyn Error>> {
-        // `device` may be a numeric index ("0") or a path like "/dev/video0".
-        // Try parsing as an index first, otherwise fall back to opening by path.
+    pub fn new(device: &str, width: u32, height: u32, use_rpi: bool) -> Result<Self, Box<dyn Error>> {
+        if use_rpi {
+            #[cfg(feature = "picam")]
+            {
+                let cam = picam::Picam::new(device, width, height)?;
+                return Ok(Camera { backend: CameraBackend::Pi(cam) });
+            }
+            #[cfg(not(feature = "picam"))]
+            {
+                return Err("picam feature not enabled".into());
+            }
+        }
+
+        // Fallback to OpenCV backend
         let capture = if let Ok(index) = device.parse::<i32>() {
             videoio::VideoCapture::new(index, videoio::CAP_ANY)?
         } else {
@@ -22,15 +42,21 @@ impl Camera {
             return Err("Failed to open camera".into());
         }
 
-        Ok(Camera { capture })
+        Ok(Camera { backend: CameraBackend::OpenCv(capture) })
     }
 
     pub fn capture(&mut self) -> Result<Mat, Box<dyn Error>> {
-        let mut frame = Mat::default();
-        self.capture.read(&mut frame)?;
-        if frame.empty() {
-            return Err("Failed to capture image".into());
+        match &mut self.backend {
+            CameraBackend::OpenCv(cap) => {
+                let mut frame = Mat::default();
+                cap.read(&mut frame)?;
+                if frame.empty() {
+                    return Err("Failed to capture image".into());
+                }
+                Ok(frame)
+            }
+            #[cfg(feature = "picam")]
+            CameraBackend::Pi(cam) => cam.capture(),
         }
-        Ok(frame)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,9 @@ pub struct CameraConfig {
     pub device: String,
     pub resolution_width: u32,
     pub resolution_height: u32,
+    /// Use the Raspberry Pi camera via V4L2
+    #[serde(default)]
+    pub use_rpi_cam: bool,
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     info!("Config loaded from {}", cli.config);
 
     // 2. Camera
-    let mut camera = Camera::new(&config.camera.device)?;
+    let mut camera = Camera::new(
+        &config.camera.device,
+        config.camera.resolution_width,
+        config.camera.resolution_height,
+        config.camera.use_rpi_cam,
+    )?;
     info!("Camera initialised");
 
     // 3. Detection

--- a/src/picam.rs
+++ b/src/picam.rs
@@ -1,0 +1,27 @@
+use opencv::{imgcodecs, core::{self, Vector}, prelude::*};
+use rscam::{Camera as PiCamera, Config as PiConfig};
+use std::error::Error;
+
+pub struct Picam {
+    camera: PiCamera,
+}
+
+impl Picam {
+    pub fn new(device: &str, width: u32, height: u32) -> Result<Self, Box<dyn Error>> {
+        let mut cam = PiCamera::new(device)?;
+        cam.start(&PiConfig {
+            interval: (1, 30),
+            resolution: (width, height),
+            format: b"MJPG",
+            ..Default::default()
+        })?;
+        Ok(Picam { camera: cam })
+    }
+
+    pub fn capture(&mut self) -> Result<Mat, Box<dyn Error>> {
+        let frame = self.camera.capture()?;
+        let data = Vector::from_slice(&frame);
+        let mat = imgcodecs::imdecode(&data, imgcodecs::IMREAD_COLOR)?;
+        Ok(mat)
+    }
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -4,5 +4,6 @@ use rustspray::config::Config;
 fn load_config_values() {
     let cfg = Config::load("config/Config.toml").expect("load config");
     assert_eq!(cfg.camera.device, "/dev/video2");
+    assert!(!cfg.camera.use_rpi_cam);
     assert_eq!(cfg.spray.pins[0], 23);
 }


### PR DESCRIPTION
## Summary
- support Raspberry Pi camera via new optional `picam` feature using rscam
- add `use_rpi_cam` flag to configuration and document usage
- update README example config and hardware notes

## Testing
- `cargo test` *(fails: could not download crates)*