### PR TITLE
Fix missing target in pi-opencv Dockerfile

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -35,6 +35,7 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM messense/rust-musl-cross:aarch64-musl
+RUN rustup target add aarch64-unknown-linux-gnu
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
 ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib


### PR DESCRIPTION
## Summary
- add `rustup target add aarch64-unknown-linux-gnu` step to the ARM build image

## Testing
- `cargo fmt -- --check` *(fails: rustfmt not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test` *(fails: could not fetch crates)*