### PR TITLE
Fix docker buildx caching

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Log in to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -21,6 +27,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: Dockerfile.pi-opencv
           push: true


### PR DESCRIPTION
## Summary
- set up docker buildx using the docker-container driver
- pass builder name to build-push step so registry caching works

## Testing
- `cargo test --locked` *(fails: Could not connect to server)*