### PR TITLE
Fix Docker tag casing

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,6 +17,10 @@ jobs:
         with:
           driver: docker-container
 
+      - name: Compute lowercase repo name
+        id: repo
+        run: echo "repo_lower=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Log in to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -31,15 +35,15 @@ jobs:
           context: .
           file: Dockerfile.pi-opencv
           push: true
-          tags: ghcr.io/${{ github.repository }}/rustspray-cross-pi5:latest
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rustspray-cross-pi5:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rustspray-cross-pi5:buildcache,mode=max
+          tags: ghcr.io/${{ steps.repo.outputs.repo_lower }}/rustspray-cross-pi5:latest
+          cache-from: type=registry,ref=ghcr.io/${{ steps.repo.outputs.repo_lower }}/rustspray-cross-pi5:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ steps.repo.outputs.repo_lower }}/rustspray-cross-pi5:buildcache,mode=max
 
       - name: Build inside Docker container
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
-            ghcr.io/${{ github.repository }}/rustspray-cross-pi5:latest \
+            ghcr.io/${{ steps.repo.outputs.repo_lower }}/rustspray-cross-pi5:latest \
             bash -c "cd /workspace && cargo build --release --target aarch64-unknown-linux-gnu"
 
       - name: Upload Pi5 binary artifact


### PR DESCRIPTION
## Summary
- fix docker image tags to use lowercase repo names

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*