### PR TITLE
Enable CI on green-on-green branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ubi_multi_platform_build_and_release
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "green-on-green" ]
     tags: [ "v*" ]
   workflow_dispatch:
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,7 +2,7 @@ name: Build-in-Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, green-on-green]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: "0 3 * * *"             # nightly at 03:00 UTC  (adjust if you like)
   push:
-    branches: [main]                # also run after every push to main
+    branches: [main, green-on-green]                # also run after every push to main
 
 # ────────────────────── Permissions ───────────────────────
 permissions:


### PR DESCRIPTION
## Summary
- run workflows when pushing to `green-on-green`

## Testing
- `cargo test --no-run` *(fails: could not download crates)*