### PR TITLE
Fix apt sources to avoid build failures

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,7 +1,9 @@
 FROM messense/rust-musl-cross:aarch64-musl as builder
 
 # Install required dependencies for OpenCV
-RUN apt-get update && \
+# Use a mirror that is more reliable in CI environments and retry
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \


### PR DESCRIPTION
## Summary
- use Azure mirror for apt-get in Dockerfile
- retry apt update to handle transient network errors

## Testing
- `cargo test` *(fails: could not download from crates.io)*