### PR TITLE
Add project wiki docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Rust-Spray is implemented as a set of cooperative asynchronous tasks orchestrate
 - **Camera (Optional):** Pi HQ Camera v2 or USB camera for OpenCV processing.
   Enable the `picam` Cargo feature and set `camera.use_rpi_cam = true` to use the Pi camera module.
 
-Refer to the project wiki for wiring diagrams and recommended peripherals.
+Refer to the [wiki](wiki) for wiring diagrams and recommended peripherals.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,18 @@
+# Rust-Spray Wiki
+
+Welcome to the **Rust-Spray** project wiki. This section provides
+additional documentation beyond the main `README`. It covers
+installation, hardware wiring, and operational guidance.
+
+## Pages
+
+- [Installation Guide](Installation.md)
+- [Wiring and Hardware](Wiring.md)
+
+## Overview
+
+Rust-Spray is a real-time spraying controller written in Rust for
+embedded Linux systems. It integrates CAN bus messages, GPS data and
+(optional) camera vision to accurately control sprayer boom sections.
+
+For high level features and design goals see the [`README.md`](../README.md).

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,59 @@
+# Installation Guide
+
+This page expands on the installation steps found in the main README.
+It explains how to install dependencies, build the project and deploy
+it to embedded targets like the Raspberry Pi.
+
+## Prerequisites
+
+1. **Rust Toolchain** – Install with rustup:
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+2. **System Libraries** – OpenCV headers and build tools are required.
+   On Ubuntu/Debian:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install libopencv-dev pkg-config build-essential
+   ```
+   To cross compile for ARM64 also install:
+   ```bash
+   sudo apt-get install gcc-aarch64-linux-gnu
+   rustup target add aarch64-unknown-linux-gnu
+   ```
+
+## Building
+
+Clone the repository and build for your platform:
+
+```bash
+git clone https://github.com/cropcrusaders/Rust-Spray.git
+cd Rust-Spray
+cargo build --release
+```
+
+For Raspberry Pi (AArch64) cross‑compilation run:
+
+```bash
+cargo build --release --target aarch64-unknown-linux-gnu
+```
+
+After compilation copy the binary from
+`target/aarch64-unknown-linux-gnu/release/` to your device.
+
+## Deployment
+
+1. Ensure the target device has OpenCV runtime libraries installed.
+2. Bring up the CAN interface:
+   ```bash
+   sudo ip link set can0 up type can bitrate 250000
+   ```
+3. Confirm the GPS serial port (e.g. `/dev/ttyACM0`) is accessible.
+4. Copy `config/Config.toml` to `config/config.toml` and adjust settings
+   for your hardware.
+5. Run the controller with the appropriate command line options:
+   ```bash
+   sudo ./target/release/rust-spray --sections 16 \
+        --gps /dev/ttyACM0 --can if=can0,bitrate=250000 \
+        --config config/config.toml
+   ```

--- a/wiki/Wiring.md
+++ b/wiki/Wiring.md
@@ -1,0 +1,40 @@
+# Wiring and Hardware
+
+This document provides guidance on connecting common peripherals to a
+Raspberry Pi based setup. Adapt the pin numbers and interfaces for your
+hardware as needed.
+
+## Required Components
+
+- **Solenoid Valves** – e.g. TeeJet 344E
+- **CAN Interface** – PiCAN3 HAT or any SocketCAN adapter
+- **Flow Sensor** – DigiFlow 200 (optional)
+- **GPS Receiver** – u-blox F9P or similar
+- **Camera** (optional) – Pi HQ Camera v2 or USB webcam
+
+## Example GPIO Mapping
+
+The sample `config/Config.toml` uses the following GPIO pins for four
+sprayer outputs:
+
+| Section | GPIO Pin |
+|---------|---------:|
+| 1       | 23       |
+| 2       | 24       |
+| 3       | 25       |
+| 4       | 26       |
+
+Adjust these pins in `config/config.toml` to match your wiring.
+
+## Power and Safety
+
+- Ensure that valve drivers and pumps have adequate power supplies.
+- Use proper fusing and emergency stop hardware.
+- The software defaults to valves off if errors occur, but always verify
+  fail‑safe behaviour with your specific hardware.
+
+## Diagrams
+
+Detailed wiring diagrams will be provided in future revisions of this
+wiki. For now, refer to the table above and the comments in
+`config/Config.toml` for connection hints.


### PR DESCRIPTION
## Summary
- add wiki folder with home page
- document installation process in the wiki
- add wiring and hardware information
- link README to the local wiki

## Testing
- `cargo test` *(fails: failed to get `clap` as a dependency)*