### PR TITLE
Enable GHCR push in Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-in-docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant packages: write permission for docker workflow so that pushes to ghcr succeed

## Testing
- `cargo test --locked` *(fails: could not connect to server)*