### PR TITLE
Fix missing pkg-config in cross image

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -37,6 +37,8 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM messense/rust-musl-cross:aarch64-musl
+RUN apt-get update -o Acquire::Retries=5 && \
+    apt-get install -y pkg-config
 RUN rustup target add aarch64-unknown-linux-gnu
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig


### PR DESCRIPTION
## Summary
- add `pkg-config` installation to the final Docker stage so cross builds can find it

## Testing
- `cargo test --locked --target x86_64-unknown-linux-gnu` *(fails: could not connect to crates.io)*