### PR TITLE
Fix cross container OpenCV paths

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -33,12 +33,22 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
     mkdir -p /aarch64-linux-gnu/include && \
     cp -r /usr/local/include/* /aarch64-linux-gnu/include/ && \
     mkdir -p /aarch64-linux-gnu/lib/pkgconfig && \
-    cp /usr/local/lib/pkgconfig/opencv4.pc /aarch64-linux-gnu/lib/pkgconfig/
+    cp /usr/local/lib/pkgconfig/opencv4.pc /aarch64-linux-gnu/lib/pkgconfig/ && \
+    # Also copy files into the musl sysroot used by rust-musl-cross
+    mkdir -p /usr/local/musl/aarch64-unknown-linux-musl/lib && \
+    cp -r /usr/local/lib/* /usr/local/musl/aarch64-unknown-linux-musl/lib/ && \
+    mkdir -p /usr/local/musl/aarch64-unknown-linux-musl/include && \
+    cp -r /usr/local/include/* /usr/local/musl/aarch64-unknown-linux-musl/include/ && \
+    mkdir -p /usr/local/musl/aarch64-unknown-linux-musl/lib/pkgconfig && \
+    cp /usr/local/lib/pkgconfig/opencv4.pc /usr/local/musl/aarch64-unknown-linux-musl/lib/pkgconfig/
 
 # Final image: will be used by cross
 FROM messense/rust-musl-cross:aarch64-musl
+RUN apt-get update -o Acquire::Retries=5 && \
+    apt-get install -y pkg-config
 RUN rustup target add aarch64-unknown-linux-gnu
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
-ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
-ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
-ENV LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
+COPY --from=builder /usr/local/musl/aarch64-unknown-linux-musl /usr/local/musl/aarch64-unknown-linux-musl
+ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig:/usr/local/musl/aarch64-unknown-linux-musl/lib/pkgconfig
+ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib:/usr/local/musl/aarch64-unknown-linux-musl/lib
+ENV LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib:/usr/local/musl/aarch64-unknown-linux-musl/lib


### PR DESCRIPTION
## Summary
- copy OpenCV headers and libs into the musl sysroot when building the cross
  container
- include the musl sysroot in `PKG_CONFIG_PATH`, `LIBRARY_PATH`, and
  `LD_LIBRARY_PATH`

## Testing
- `cargo test --locked --target x86_64-unknown-linux-gnu` *(fails: could not fetch crates)*