### PR TITLE
Fix cross container host compiler

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -37,8 +37,13 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM messense/rust-musl-cross:aarch64-musl
+RUN apt-get update -o Acquire::Retries=5 && \
+    apt-get install -y pkg-config
 RUN rustup target add aarch64-unknown-linux-gnu
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
 ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
 ENV LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
+ENV CC_x86_64_unknown_linux_gnu=/usr/bin/gcc
+ENV CXX_x86_64_unknown_linux_gnu=/usr/bin/g++
+ENV AR_x86_64_unknown_linux_gnu=/usr/bin/ar


### PR DESCRIPTION
## Summary
- set host compiler variables in `Dockerfile.pi-opencv`

## Testing
- `cargo test --locked --target x86_64-unknown-linux-gnu` *(fails: could not fetch crates)*
