### PR TITLE
Fix host build by disabling forced cross compile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,9 @@
 [target.aarch64-unknown-linux-gnu]
 runner = "cross"
 
-[build]
-target = "aarch64-unknown-linux-gnu"
+#[build]
+# Uncomment to cross compile for Raspberry Pi
+# target = "aarch64-unknown-linux-gnu"
 
 [unstable]
 build-std = ["std"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ To cross compile for Raspberry Pi (AArch64):
    rustup target add aarch64-unknown-linux-gnu
    cargo build --release --target aarch64-unknown-linux-gnu
    ```
+Alternatively, uncomment the `target` line in `.cargo/config.toml` to make
+cross compilation the default.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- don't enforce aarch64 in `.cargo/config.toml`
- clarify cross compile instructions in README

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*