### PR TITLE
Add musl linker target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,9 @@
 runner = "cross"
 linker = "aarch64-linux-gnu-gcc"
 
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+
 #[build]
 # Uncomment to cross compile for Raspberry Pi
 # target = "aarch64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- add musl configuration to `.cargo/config.toml`

## Testing
- `cargo test` *(fails: could not download crates)*