### PR TITLE
Add cross build action

### DIFF
--- a/.github/workflows/cross-aarch64.yml
+++ b/.github/workflows/cross-aarch64.yml
@@ -1,0 +1,34 @@
+name: Cross Build for Raspberry Pi
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Build custom cross image
+        run: docker build -t custom/aarch64-opencv -f Dockerfile.pi-opencv .
+
+      - name: Cross build for Raspberry Pi
+        run: cross build --release --target aarch64-unknown-linux-gnu
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustspray-aarch64
+          path: target/aarch64-unknown-linux-gnu/release/rustspray


### PR DESCRIPTION
## Summary
- add GitHub workflow to build Raspberry Pi aarch64 binary using `cross`

## Testing
- `cargo test --quiet` *(fails: Could not connect to server)*