### PR TITLE
Fix cross compile image

### DIFF
--- a/.github/workflows/cross-aarch64.yml
+++ b/.github/workflows/cross-aarch64.yml
@@ -1,0 +1,34 @@
+name: Cross Build for Raspberry Pi
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Build custom cross image
+        run: docker build -t custom/aarch64-opencv -f Dockerfile.pi-opencv .
+
+      - name: Cross build for Raspberry Pi
+        run: cross build --release --target aarch64-unknown-linux-gnu
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustspray-aarch64
+          path: target/aarch64-unknown-linux-gnu/release/rustspray

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,4 +1,4 @@
-FROM messense/rust-musl-cross:aarch64-musl as builder
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge as builder
 
 # Install required dependencies for OpenCV
 # Use a mirror that is more reliable in CI environments and retry
@@ -33,22 +33,14 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
     mkdir -p /aarch64-linux-gnu/include && \
     cp -r /usr/local/include/* /aarch64-linux-gnu/include/ && \
     mkdir -p /aarch64-linux-gnu/lib/pkgconfig && \
-    cp /usr/local/lib/pkgconfig/opencv4.pc /aarch64-linux-gnu/lib/pkgconfig/ && \
-    # Also copy files into the musl sysroot used by rust-musl-cross
-    mkdir -p /usr/local/musl/aarch64-unknown-linux-musl/lib && \
-    cp -r /usr/local/lib/* /usr/local/musl/aarch64-unknown-linux-musl/lib/ && \
-    mkdir -p /usr/local/musl/aarch64-unknown-linux-musl/include && \
-    cp -r /usr/local/include/* /usr/local/musl/aarch64-unknown-linux-musl/include/ && \
-    mkdir -p /usr/local/musl/aarch64-unknown-linux-musl/lib/pkgconfig && \
-    cp /usr/local/lib/pkgconfig/opencv4.pc /usr/local/musl/aarch64-unknown-linux-musl/lib/pkgconfig/
+    cp /usr/local/lib/pkgconfig/opencv4.pc /aarch64-linux-gnu/lib/pkgconfig/
 
 # Final image: will be used by cross
-FROM messense/rust-musl-cross:aarch64-musl
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 RUN rustup target add aarch64-unknown-linux-gnu
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
-COPY --from=builder /usr/local/musl/aarch64-unknown-linux-musl /usr/local/musl/aarch64-unknown-linux-musl
-ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig:/usr/local/musl/aarch64-unknown-linux-musl/lib/pkgconfig
-ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib:/usr/local/musl/aarch64-unknown-linux-musl/lib
-ENV LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib:/usr/local/musl/aarch64-unknown-linux-musl/lib
+ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
+ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
+ENV LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib


### PR DESCRIPTION
## Summary
- update Dockerfile to build from cross-rs AArch64 GNU image

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*