### PR TITLE
Fix Docker image build error

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -39,7 +39,6 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
-RUN rustup target add aarch64-unknown-linux-gnu
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
 ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib


### PR DESCRIPTION
## Summary
- remove rustup command from Dockerfile since the cross image already has necessary target

## Testing
- `cargo --version`
- `cargo test` *(fails: Could not connect to server)*