### PR TITLE
Fix cross-runner issue

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.aarch64-unknown-linux-gnu]
-runner = "cross"
+# Use the standard linker for Raspberry Pi builds. The `cross`
+# tool can still be used manually but is no longer required.
 linker = "aarch64-linux-gnu-gcc"
 
 [target.aarch64-unknown-linux-musl]


### PR DESCRIPTION
## Summary
- remove `cross` as the default runner for aarch64

## Testing
- `cargo test`
- `cargo build`
- `cargo build --release --target aarch64-unknown-linux-gnu` *(fails: ToolNotFound: `aarch64-linux-gnu-g++`)*