### PR TITLE
Add Raspberry Pi package release

### DIFF
--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -1,0 +1,38 @@
+name: Raspberry Pi Debian Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Install cross and cargo-deb
+        run: cargo install cross cargo-deb
+
+      - name: Build custom cross image
+        run: docker build -t custom/aarch64-opencv -f Dockerfile.pi-opencv .
+
+      - name: Cross build
+        run: cross build --release --target aarch64-unknown-linux-gnu
+
+      - name: Build Debian package
+        run: cargo deb --no-build --target aarch64-unknown-linux-gnu
+
+      - name: Upload Debian package
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: target/aarch64-unknown-linux-gnu/debian/rustspray_*.deb
+          asset_name: rustspray_${{ github.event.release.tag_name }}_arm64.deb
+          asset_content_type: application/vnd.debian.binary-package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ thiserror  = "1.0"
 
 # Raspberry Pi GPIO support (enabled only on ARM platforms)
 rppal = { version = "0.15", optional = true }
+
 # Raspberry Pi camera (V4L2)
 rscam = { version = "0.5", optional = true }
 
@@ -50,3 +51,13 @@ picam      = ["rscam"]
 # Platform guard: only include `rppal` on ARM and AARCH64 targets
 [target.'cfg(not(any(target_arch = "arm", target_arch = "aarch64")))'.dependencies]
 rppal = { version = "0.15", optional = true }
+
+[package.metadata.deb]
+maintainer = "Crop Crusaders <dev@cropcrusaders.com>"
+license-file = ["LICENSE"]
+depends = "libc6"
+assets = [
+  ["target/aarch64-unknown-linux-gnu/release/rustspray", "usr/bin/", "755"],
+  ["config/Config.toml", "etc/rustspray/config.toml", "644"],
+]
+

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,10 +1,8 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge as builder
 
 # Install required dependencies for OpenCV
-# Use a mirror that is more reliable in CI environments and retry
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+# Retry `apt-get update` to mitigate transient network issues
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ The repository's `.cargo/config.toml` configures the linker as `aarch64-linux-gn
 Alternatively, uncomment the `target` line in `.cargo/config.toml` to make
 cross compilation the default.
 
+### Pre-built Raspberry Pi Package
+
+GitHub Actions builds a Debian package for Raspberry Pi (ARM64) on every
+release. Download the latest `rustspray_*.deb` from the
+[releases page](https://github.com/cropcrusaders/Rust-Spray/releases) and
+install it on the Pi with:
+
+```bash
+sudo dpkg -i rustspray_*_arm64.deb
+```
+
+
 ## Configuration
 
 Copy `config/Config.toml` to `config/config.toml` and edit as needed:

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -41,6 +41,14 @@ cargo build --release --target aarch64-unknown-linux-gnu
 After compilation copy the binary from
 `target/aarch64-unknown-linux-gnu/release/` to your device.
 
+Alternatively download the pre-built Debian package from the
+[GitHub releases](https://github.com/cropcrusaders/Rust-Spray/releases)
+page and install it on the Raspberry Pi:
+
+```bash
+sudo dpkg -i rustspray_*_arm64.deb
+```
+
 ## Deployment
 
 1. Ensure the target device has OpenCV runtime libraries installed.


### PR DESCRIPTION
## Summary
- add pre-built Raspberry Pi package instructions in README
- mention Debian package in Installation wiki
- provide cargo-deb metadata
- add GitHub workflow to build `.deb`
- fix Dockerfile apt sources

## Testing
- `cargo test`
