### PR TITLE
Clarify cargo PATH after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Rust-Spray is a small example project that uses a camera to detect weeds and pul
 
 ## Beginner Quickstart
 
-1. **Install Rust and OpenCV development libraries**
+1. **Install Rust, Cargo and OpenCV development libraries**
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   # Add cargo to PATH for the current shell
+   source "$HOME/.cargo/env"
    sudo apt-get update
    sudo apt-get install libopencv-dev pkg-config build-essential
+   cargo install cargo-opencv
    ```
 2. **Clone this repository**
    ```bash


### PR DESCRIPTION
## Summary
- add a step to source `$HOME/.cargo/env` so that `cargo` is available after installing Rust

## Testing
- `cargo test --quiet`
