### PR TITLE
Fix apt sources to use https in Dockerfile

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -2,7 +2,8 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge as builder
 
 # Install required dependencies for OpenCV
 # Retry `apt-get update` to mitigate transient network issues
-RUN apt-get update -o Acquire::Retries=5 && \
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -36,7 +37,8 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
-RUN apt-get update -o Acquire::Retries=5 && \
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig


### PR DESCRIPTION
## Summary
- patch Dockerfile to use HTTPS for Ubuntu repositories before apt updates

## Testing
- `cargo test --quiet`
