### PR TITLE
Update cargo-opencv install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Rust-Spray is a small example project that uses a camera to detect weeds and pul
 
 ## Beginner Quickstart
 
-1. **Install Rust and OpenCV development libraries**
+1. **Install Rust, Cargo and OpenCV development libraries**
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   source "$HOME/.cargo/env"
    sudo apt-get update
    sudo apt-get install libopencv-dev pkg-config build-essential
+   cargo install cargo-opencv --git https://github.com/twistedfall/opencv-rust
    ```
 2. **Clone this repository**
    ```bash


### PR DESCRIPTION
## Summary
- load Cargo environment after installing Rust
- install cargo-opencv from the opencv-rust GitHub repo

## Testing
- `cargo test --quiet`
