### PR TITLE
Add armv7 CI builds

### DIFF
--- a/.github/workflows/cross-aarch64.yml
+++ b/.github/workflows/cross-aarch64.yml
@@ -9,6 +9,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            dockerfile: Dockerfile.pi-opencv
+            image: custom/aarch64-opencv
+            arch: aarch64
+          - target: armv7-unknown-linux-gnueabihf
+            dockerfile: Dockerfile.pi-opencv-armv7
+            image: custom/armv7-opencv
+            arch: armv7
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -16,19 +27,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-unknown-linux-gnu
+          targets: ${{ matrix.target }}
 
       - name: Install cross
         run: cargo install cross
 
       - name: Build custom cross image
-        run: docker build -t custom/aarch64-opencv -f Dockerfile.pi-opencv .
+        run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
 
       - name: Cross build for Raspberry Pi
-        run: cross build --release --target aarch64-unknown-linux-gnu
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rustspray-aarch64
-          path: target/aarch64-unknown-linux-gnu/release/rustspray
+          name: rustspray-${{ matrix.arch }}
+          path: target/${{ matrix.target }}/release/rustspray

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -8,6 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            dockerfile: Dockerfile.pi-opencv
+            image: custom/aarch64-opencv
+            arch: arm64
+          - target: armv7-unknown-linux-gnueabihf
+            dockerfile: Dockerfile.pi-opencv-armv7
+            image: custom/armv7-opencv
+            arch: armv7
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -15,24 +26,24 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-unknown-linux-gnu
+          targets: ${{ matrix.target }}
 
       - name: Install cross and cargo-deb
         run: cargo install cross cargo-deb
 
       - name: Build custom cross image
-        run: docker build -t custom/aarch64-opencv -f Dockerfile.pi-opencv .
+        run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
 
       - name: Cross build
-        run: cross build --release --target aarch64-unknown-linux-gnu
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Build Debian package
-        run: cargo deb --no-build --target aarch64-unknown-linux-gnu
+        run: cargo deb --no-build --target ${{ matrix.target }}
 
       - name: Upload Debian package
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: target/aarch64-unknown-linux-gnu/debian/rustspray_*.deb
-          asset_name: rustspray_${{ github.event.release.tag_name }}_arm64.deb
+          asset_path: target/${{ matrix.target }}/debian/rustspray_*.deb
+          asset_name: rustspray_${{ github.event.release.tag_name }}_${{ matrix.arch }}.deb
           asset_content_type: application/vnd.debian.binary-package

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
 image = "custom/aarch64-opencv"
+
+[target.armv7-unknown-linux-gnueabihf]
+image = "custom/armv7-opencv"

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -1,0 +1,48 @@
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge as builder
+
+# Install required dependencies for OpenCV
+# Retry `apt-get update` to mitigate transient network issues
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
+    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
+    apt-get update -o Acquire::Retries=5 && \
+    apt-get install -y \
+      pkg-config \
+      libgtk-3-dev \
+      libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+      libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
+      openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
+      libdc1394-dev cmake git clang
+
+# Build and install OpenCV for ARMv7
+WORKDIR /opt
+RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv_contrib.git && \
+    mkdir -p build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DOPENCV_GENERATE_PKGCONFIG=ON \
+        -DOPENCV_EXTRA_MODULES_PATH=/opt/opencv_contrib/modules \
+        -DOPENCV_ENABLE_NONFREE=ON \
+        -DENABLE_PRECOMPILED_HEADERS=OFF \
+        -DBUILD_opencv_legacy=OFF \
+        ../opencv && \
+    make -j$(nproc) && make install
+
+# Copy OpenCV libraries and pkg-config file to sysroot
+RUN mkdir -p /arm-linux-gnueabihf/lib && \
+    cp -r /usr/local/lib/* /arm-linux-gnueabihf/lib/ && \
+    mkdir -p /arm-linux-gnueabihf/include && \
+    cp -r /usr/local/include/* /arm-linux-gnueabihf/include/ && \
+    mkdir -p /arm-linux-gnueabihf/lib/pkgconfig && \
+    cp /usr/local/lib/pkgconfig/opencv4.pc /arm-linux-gnueabihf/lib/pkgconfig/
+
+# Final image: will be used by cross
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
+RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
+    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
+    apt-get update -o Acquire::Retries=5 && \
+    apt-get install -y pkg-config
+COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
+ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
+ENV LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib
+ENV LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib


### PR DESCRIPTION
## Summary
- support both arm64 and armv7 targets in CI
- create Dockerfile for armv7 cross build image
- package armv7 Debian artifacts

## Testing
- `cargo test`