### PR TITLE
Add armv7 linker target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,9 @@ linker = "aarch64-linux-gnu-gcc"
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
 
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
 #[build]
 # Uncomment to cross compile for Raspberry Pi
 # target = "aarch64-unknown-linux-gnu"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To cross compile for Raspberry Pi (AArch64):
    cargo build --release --target aarch64-unknown-linux-gnu
    ```
 The repository's `.cargo/config.toml` configures the linker as `aarch64-linux-gnu-gcc` for this target.
+It also defines a linker for the 32-bit `armv7-unknown-linux-gnueabihf` target so you can cross compile for older Raspberry Pi models.
 Alternatively, uncomment the `target` line in `.cargo/config.toml` to make
 cross compilation the default.
 


### PR DESCRIPTION
## Summary
- set `arm-linux-gnueabihf-gcc` linker for the armv7 target
- mention the armv7 config in the build instructions

## Testing
- `cargo test`