### PR TITLE
Implement cross image caching

### DIFF
--- a/.github/workflows/cross-aarch64.yml
+++ b/.github/workflows/cross-aarch64.yml
@@ -32,8 +32,24 @@ jobs:
       - name: Install cross
         run: cargo install cross
 
+      - name: Restore cached cross image
+        id: cache-cross
+        uses: actions/cache@v3
+        with:
+          path: cross-image-${{ matrix.arch }}.tar
+          key: ${{ runner.os }}-${{ matrix.image }}-${{ hashFiles(matrix.dockerfile) }}
+
+      - name: Load cross image
+        if: steps.cache-cross.outputs.cache-hit == 'true'
+        run: docker load -i cross-image-${{ matrix.arch }}.tar
+
       - name: Build custom cross image
+        if: steps.cache-cross.outputs.cache-hit != 'true'
         run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
+
+      - name: Save cross image
+        if: steps.cache-cross.outputs.cache-hit != 'true'
+        run: docker save ${{ matrix.image }} -o cross-image-${{ matrix.arch }}.tar
 
       - name: Cross build for Raspberry Pi
         run: cross build --release --target ${{ matrix.target }}

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -31,8 +31,24 @@ jobs:
       - name: Install cross and cargo-deb
         run: cargo install cross cargo-deb
 
+      - name: Restore cached cross image
+        id: cache-cross
+        uses: actions/cache@v3
+        with:
+          path: cross-image-${{ matrix.arch }}.tar
+          key: ${{ runner.os }}-${{ matrix.image }}-${{ hashFiles(matrix.dockerfile) }}
+
+      - name: Load cross image
+        if: steps.cache-cross.outputs.cache-hit == 'true'
+        run: docker load -i cross-image-${{ matrix.arch }}.tar
+
       - name: Build custom cross image
+        if: steps.cache-cross.outputs.cache-hit != 'true'
         run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
+
+      - name: Save cross image
+        if: steps.cache-cross.outputs.cache-hit != 'true'
+        run: docker save ${{ matrix.image }} -o cross-image-${{ matrix.arch }}.tar
 
       - name: Cross build
         run: cross build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- reuse Docker build layers to speed up cross-compiled builds
- cache the custom cross Docker images in CI workflows

## Testing
- `cargo test`