### PR TITLE
Fix apt 403 errors in cross Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -2,9 +2,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge as builder
 
 # Install required dependencies for OpenCV
 # Retry `apt-get update` to mitigate transient network issues
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
-    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
-    apt-get update -o Acquire::Retries=5 && \
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -38,9 +36,7 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
-    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
-    apt-get update -o Acquire::Retries=5 && \
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -2,9 +2,7 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge as builder
 
 # Install required dependencies for OpenCV
 # Retry `apt-get update` to mitigate transient network issues
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
-    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
-    apt-get update -o Acquire::Retries=5 && \
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -38,9 +36,7 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
-    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
-    apt-get update -o Acquire::Retries=5 && \
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -2,9 +2,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge as builder
 
 # Install required dependencies for OpenCV
 # Retry `apt-get update` to mitigate transient network issues
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
-    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
-    apt-get update -o Acquire::Retries=5 && \
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -38,9 +36,7 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN sed -i 's|http://|https://|g' /etc/apt/sources.list && \
-    find /etc/apt/sources.list.d -type f -exec sed -i 's|http://|https://|g' {} + 2>/dev/null || true && \
-    apt-get update -o Acquire::Retries=5 && \
+RUN apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig


### PR DESCRIPTION
## Summary
- avoid rewriting apt sources to https in Dockerfiles
- keep retry logic but use default mirrors

## Testing
- `cargo test --locked`