### PR TITLE
Fix apt sources in Dockerfiles

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,8 +1,13 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge as builder
 
 # Install required dependencies for OpenCV
-# Retry `apt-get update` to mitigate transient network issues
-RUN apt-get update -o Acquire::Retries=5 && \
+# The base image occasionally contains an invalid Ubuntu mirror URL
+# ("archive.archive.ubuntu.com") which results in 403 errors during
+# package retrieval. Replace it with the correct mirror before running
+# `apt-get update`.
+RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -36,7 +41,9 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
-RUN apt-get update -o Acquire::Retries=5 && \
+RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -1,8 +1,13 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge as builder
 
 # Install required dependencies for OpenCV
-# Retry `apt-get update` to mitigate transient network issues
-RUN apt-get update -o Acquire::Retries=5 && \
+# The base image occasionally contains an invalid Ubuntu mirror URL
+# ("archive.archive.ubuntu.com") which results in 403 errors during
+# package retrieval. Replace it with the correct mirror before running
+# `apt-get update`.
+RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -36,7 +41,9 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN apt-get update -o Acquire::Retries=5 && \
+RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig


### PR DESCRIPTION
## Summary
- fix invalid Ubuntu mirror in Dockerfiles to avoid 403 errors

## Testing
- `cargo test --quiet`
