### PR TITLE
Fix apt fetch errors in Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -1,8 +1,11 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge as builder
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
 # Retry `apt-get update` to mitigate transient network issues
-RUN apt-get update -o Acquire::Retries=5 && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -36,7 +39,9 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN apt-get update -o Acquire::Retries=5 && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+    apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,12 +1,14 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge as builder
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge AS builder
 
 # Install required dependencies for OpenCV
 # The base image occasionally contains an invalid Ubuntu mirror URL
 # ("archive.archive.ubuntu.com") which results in 403 errors during
 # package retrieval. Replace it with the correct mirror before running
 # `apt-get update`.
-RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
     apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
@@ -41,8 +43,10 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
-RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
     apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -1,12 +1,14 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge as builder
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
 # The base image occasionally contains an invalid Ubuntu mirror URL
 # ("archive.archive.ubuntu.com") which results in 403 errors during
 # package retrieval. Replace it with the correct mirror before running
 # `apt-get update`.
-RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
     apt-get update -o Acquire::Retries=5 && \
     apt-get install -y \
       pkg-config \
@@ -41,8 +43,10 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN sed -i 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-        /etc/apt/sources.list /etc/apt/sources.list.d/*.list && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
     apt-get update -o Acquire::Retries=5 && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf


### PR DESCRIPTION
## Summary
- update apt mirrors to azure mirror across Dockerfiles
- fix FROM/AS casing lint warnings

## Testing
- `cargo test --quiet`