### PR TITLE
Fix apt mirror issues in OpenCV Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -4,8 +4,10 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # Retry `apt-get update` to mitigate transient network issues
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
+            -e 's|http://|https://|g' \
             -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    apt-get update && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -40,8 +42,11 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+        | xargs -0 sed -i \
+            -e 's|http://|https://|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    apt-get update && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -7,9 +7,11 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge AS builder
 # `apt-get update`.
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
+            -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
             -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    apt-get update && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -45,9 +47,11 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
+            -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
             -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    apt-get update && \
     apt-get install -y pkg-config
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -7,9 +7,11 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # `apt-get update`.
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
+            -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
             -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    apt-get update && \
     apt-get install -y \
       pkg-config \
       libgtk-3-dev \
@@ -45,9 +47,11 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
+            -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
             -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
-    apt-get update -o Acquire::Retries=5 && \
+    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    apt-get update && \
     apt-get install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig


### PR DESCRIPTION
## Summary
- force HTTPS and disable HTTP pipelining in Dockerfiles to avoid intermittent 403 errors from Ubuntu mirrors
- keep installing OpenCV build dependencies

## Testing
- `cargo check`
- `cargo test`
