### PR TITLE
Configure workflows for self-hosted runners

### DIFF
--- a/.github/workflows/cross-aarch64.yml
+++ b/.github/workflows/cross-aarch64.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     strategy:
       matrix:
         include:
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     strategy:
       matrix:
         include:
@@ -22,6 +22,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- switch cross build and Debian release actions to `self-hosted` runners
- install Docker during workflow setup so self-hosted agents can build

## Testing
- `cargo test`