### PR TITLE
Add Windows Docker build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,49 @@ Alternatively, uncomment the `target` line in `.cargo/config.toml` to make cross
 When using `cross`, ensure Docker is available. If it prints `Falling back to cargo on the host`, the container could not start and the build may fail.
 Install the `aarch64-linux-gnu` or `arm-linux-gnueabihf` toolchain and run `cargo build --target <target>` as a fallback.
 
+## Building with Docker
+
+If you prefer to build inside a container you can create the images used by
+`cross` from the provided Dockerfiles.
+
+```bash
+# For 64-bit ARM targets
+docker build -f Dockerfile.pi-opencv -t custom/aarch64-opencv .
+
+# For 32-bit ARM targets
+docker build -f Dockerfile.pi-opencv-armv7 -t custom/armv7-opencv .
+```
+
+Install [`cross`](https://github.com/cross-rs/cross) and build using the image:
+
+```bash
+cargo install cross
+cross build --release --target aarch64-unknown-linux-gnu
+```
+
+Replace the target as needed. You can also run arbitrary commands inside the
+image, for example:
+
+```bash
+docker run --rm -it -v $(pwd):/project -w /project custom/aarch64-opencv cargo test
+```
+
+### Windows
+
+Rust-Spray targets Linux boards, but you can cross compile from Windows using
+the Docker setup above. Install [Docker Desktop](https://www.docker.com/products/docker-desktop)
+with the WSL2 backend and ensure `cargo` is available (either through WSL or
+native rustup). Clone the repository and run:
+
+```bash
+git clone https://github.com/cropcrusaders/Rust-Spray.git
+cd Rust-Spray
+cargo install cross
+cross build --release --target aarch64-unknown-linux-gnu
+```
+
+Make sure Docker Desktop is running so that `cross` can launch its container.
+You may also run other commands with `docker run` as shown above.
 
 ### Pre-built Raspberry Pi Package
 


### PR DESCRIPTION
## Summary
- document how Windows users can build using Docker Desktop and cross

## Testing
- `cargo test`
