### PR TITLE
Add Yocto build workflow

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -1,0 +1,27 @@
+name: Yocto Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+jobs:
+  build-yocto:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
+      - name: Set up Poky build environment
+        run: |
+          source yocto/poky/oe-init-build-env yocto/build
+          bitbake rust-spray-image
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-spray-image
+          path: yocto/build/tmp/deploy/images

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "yocto/poky"]
+path = yocto/poky
+url = https://git.yoctoproject.org/git/poky

--- a/README.md
+++ b/README.md
@@ -196,3 +196,18 @@ The program opens the camera, runs the detection algorithm and pulses the spraye
 ## License
 
 Rust-Spray is released under the MIT license.
+
+## Yocto Build
+
+A minimal Yocto configuration is provided in the `yocto/` directory. It builds
+a small graphical demo image containing Rust-Spray using Poky. To build on a
+machine with the Yocto build dependencies installed:
+
+```bash
+cd yocto
+git submodule update --init poky
+source poky/oe-init-build-env build
+bitbake rust-spray-image
+```
+
+See `yocto/README.md` for more details.

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -1,0 +1,17 @@
+# Yocto Build Setup
+
+This directory contains a minimal Yocto build configuration for Rust-Spray.
+It provides a small example layer and image that includes a basic graphical
+interface based on the Poky `core-image-sato` image.
+
+Steps to build locally:
+
+```bash
+cd yocto
+git submodule update --init poky   # assumes poky is a submodule
+source poky/oe-init-build-env build
+bitbake rust-spray-image
+```
+
+The resulting image will be in `build/tmp/deploy/images/` and can be
+written to an SD card or run under QEMU.

--- a/yocto/build/conf/bblayers.conf
+++ b/yocto/build/conf/bblayers.conf
@@ -1,0 +1,11 @@
+BBPATH = "${TOPDIR}" 
+BBFILES ?= ""
+
+POKY_BBLAYERS := " \ 
+  ${TOPDIR}/../poky/meta \ 
+  ${TOPDIR}/../poky/meta-poky \ 
+  ${TOPDIR}/../poky/meta-yocto-bsp \ 
+  ${TOPDIR}/../meta-rust-spray \ 
+  "
+
+BBLAYERS ?= "${POKY_BBLAYERS}"

--- a/yocto/build/conf/local.conf
+++ b/yocto/build/conf/local.conf
@@ -1,0 +1,14 @@
+MACHINE ??= "qemuarm64"
+DISTRO ?= "poky"
+PACKAGE_CLASSES ?= "package_rpm"
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+USER_CLASSES ?= "buildstats image-prelink"
+TMPDIR = "${TOPDIR}/tmp"
+
+BB_NUMBER_THREADS = "4"
+PARALLEL_MAKE = "-j 4"
+
+IMAGE_FSTYPES += "wic"
+
+# Add rust support
+RUSTFLAGS = ""

--- a/yocto/meta-rust-spray/conf/layer.conf
+++ b/yocto/meta-rust-spray/conf/layer.conf
@@ -1,0 +1,6 @@
+# Minimal layer configuration for Rust-Spray Yocto layer
+BBPATH .= ":${LAYERDIR}"
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb"
+BBFILE_COLLECTIONS += "meta-rust-spray"
+BBFILE_PATTERN_meta-rust-spray = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-rust-spray = "6"

--- a/yocto/meta-rust-spray/recipes-apps/rust-spray/rust-spray.bb
+++ b/yocto/meta-rust-spray/recipes-apps/rust-spray/rust-spray.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Rust-Spray weed detection application"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://../../../../LICENSE;md5=9d852dbaca7af3fd17c0249a3f04e40d"
+
+SRC_URI = "git://github.com/cropcrusaders/Rust-Spray.git;branch=main"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+inherit cargo
+
+RDEPENDS:${PN} += "opencv"
+
+do_install:append() {
+    install -d ${D}${bindir}
+    install -m 0755 target/release/rustspray ${D}${bindir}/rustspray
+}

--- a/yocto/meta-rust-spray/recipes-images/rust-spray-image.bb
+++ b/yocto/meta-rust-spray/recipes-images/rust-spray-image.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Rust-Spray graphical demo image"
+LICENSE = "MIT"
+inherit core-image
+
+IMAGE_INSTALL += "rust-spray"
+
+# Use the sato GUI for a lightweight interface
+require recipes-core/images/core-image-sato.bb


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build a Yocto image on a self-hosted runner
- provide Yocto layer and image recipes with a simple graphical interface
- document Yocto build instructions

## Testing
- `cargo test` *(fails: could not fetch crates)*