### PR TITLE
Fix apt mirror replacement

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -8,8 +8,9 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -48,8 +49,9 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -8,8 +8,9 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -48,8 +49,9 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
+            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config


### PR DESCRIPTION
## Summary
- fix apt mirror substitution in Dockerfiles to avoid double `azure` prefix

## Testing
- `cargo test --locked` *(fails: Could not connect to server)*