### PR TITLE
Fix apt mirrors

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -5,7 +5,6 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -44,7 +43,6 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -9,8 +9,6 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -50,8 +48,6 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -9,8 +9,6 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -50,8 +48,6 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
             -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
-            -e 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|azure.archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config


### PR DESCRIPTION
## Summary
- use default Ubuntu mirrors instead of the azure mirror

## Testing
- `cargo test` *(fails: failed to download config.json)*