### PR TITLE
Fix apt config commands in Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -5,6 +5,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -43,6 +44,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -8,7 +8,7 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -47,7 +47,7 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -8,7 +8,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y \
@@ -47,7 +47,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' \
+            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get update && \
     apt-get install -y pkg-config


### PR DESCRIPTION
## Summary
- fix apt update commands in Dockerfiles by chaining sed and printf correctly

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*