### PR TITLE
Fix Yocto workflow submodule checkout

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -11,9 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Init submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: recursive
 
       - name: Set up Poky build environment
         run: |

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ machine with the Yocto build dependencies installed:
 
 ```bash
 cd yocto
-git submodule update --init poky
+git submodule update --init --recursive poky
 source poky/oe-init-build-env build
 bitbake rust-spray-image
 ```

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -8,7 +8,7 @@ Steps to build locally:
 
 ```bash
 cd yocto
-git submodule update --init poky   # assumes poky is a submodule
+git submodule update --init --recursive poky   # assumes poky is a submodule
 source poky/oe-init-build-env build
 bitbake rust-spray-image
 ```


### PR DESCRIPTION
## Summary
- checkout submodules automatically in Yocto workflow
- document recursive submodule update in READMEs

## Testing
- `cargo test` *(fails: could not connect to crates.io)*