### PR TITLE
Fix Yocto workflow missing poky

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Ensure Poky sources
+        run: |
+          if [ ! -e yocto/poky/oe-init-build-env ]; then
+            git clone --depth 1 https://git.yoctoproject.org/git/poky yocto/poky
+          fi
+
       - name: Set up Poky build environment
         run: |
           source yocto/poky/oe-init-build-env yocto/build

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ machine with the Yocto build dependencies installed:
 
 ```bash
 cd yocto
-git submodule update --init --recursive poky
+git clone --depth 1 https://git.yoctoproject.org/git/poky poky
 source poky/oe-init-build-env build
 bitbake rust-spray-image
 ```

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -8,7 +8,7 @@ Steps to build locally:
 
 ```bash
 cd yocto
-git submodule update --init --recursive poky   # assumes poky is a submodule
+git clone --depth 1 https://git.yoctoproject.org/git/poky poky   # fetch Poky if not using submodules
 source poky/oe-init-build-env build
 bitbake rust-spray-image
 ```


### PR DESCRIPTION
## Summary
- handle missing `yocto/poky` directory in CI by cloning Poky
- update docs to clone Poky instead of using submodules

## Testing
- `cargo test` *(fails: Could not connect to server)*