### PR TITLE
Remove README troubleshooting

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,6 +8,7 @@ installation, hardware wiring, and operational guidance.
 
 - [Installation Guide](Installation.md)
 - [Wiring and Hardware](Wiring.md)
+- [Troubleshooting](Troubleshooting.md)
 
 ## Overview
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,13 @@
+# Troubleshooting
+
+This page collects common build and runtime issues.
+
+## Cross compilation linker error
+
+When building with `cross` you might encounter an error like:
+
+```text
+/usr/aarch64-linux-gnu/lib/../lib/Scrt1.o: Relocations in generic ELF (EM: 183)
+```
+
+This usually means the build fell back to the host toolchain. Ensure the `cross` container started correctly (watch for the message `Falling back to cargo on the host`) and that the appropriate `*-linux-gnu` cross compiler packages are installed. Rebuild the Docker image if necessary and run `cross build` again.


### PR DESCRIPTION
## Summary
- revert troubleshooting section in README
- add cross-build troubleshooting note under wiki

## Testing
- `cargo test` *(fails: could not download crates)*