### PR TITLE
Remove -Ctarget-cpu=native from CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Build
         env:
           PKG_CONFIG_ALLOW_CROSS: "1"
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Ctarget-cpu=native"
+          CARGO_INCREMENTAL: "0"                 # still saves memory
         run: cross build --release --target ${{ matrix.target }} --verbose
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- update CI build step to avoid using `-Ctarget-cpu=native`

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683a23c01a848321953959df0b36a9dd