### PR TITLE
Fix cross build for Aarch64 with OpenCV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - target: aarch64-unknown-linux-gnu
             dockerfile: docker/Dockerfile.aarch64
-            image: ghcr.io/your-org/aarch64-opencv:0.2.5
+            image: ghcr.io/cropcrusaders/aarch64-opencv:0.3.0
             arch: arm64
           - target: armv7-unknown-linux-gnueabihf
             dockerfile: docker/Dockerfile.armv7

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,11 @@
+
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/your-org/aarch64-opencv:0.2.5"
+image = "ghcr.io/cropcrusaders/aarch64-opencv:0.3.0"
+dockerfile = "docker/aarch64-opencv.dockerfile"
+xargo = false
+
+[target.aarch64-unknown-linux-gnu.env]
+AR = "aarch64-linux-gnu-gcc-ar"
 
 [target.armv7-unknown-linux-gnueabihf]
 image = "ghcr.io/your-org/armv7-opencv:0.2.5"

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libopencv-dev:arm64 pkg-config ninja-build && \
+    rm -rf /var/lib/apt/lists/*
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig

--- a/tests/opencv_link.rs
+++ b/tests/opencv_link.rs
@@ -1,0 +1,7 @@
+use opencv::core::Mat;
+
+#[test]
+fn link_opencv() -> opencv::Result<()> {
+    let _mat = Mat::default();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add OpenCV cross Dockerfile for Aarch64
- configure Cross to use new image and Dockerfile
- reference new image version in CI
- add an OpenCV smoke test

## Testing
- `cargo build --release` *(fails: failed to download crates)*
- `cargo test --all-targets` *(fails: could not fetch dependencies)*
- `cargo clippy --all-targets -- -D warnings` *(fails: clippy component missing)*
- `cross build --release --target aarch64-unknown-linux-gnu` *(fails: `cross` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a35dc38588321b5a5da883bee4a0e