### PR TITLE
Update cross-rs images to 0.2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
             arch: arm64
           - target: armv7-unknown-linux-gnueabihf
             dockerfile: docker/Dockerfile.armv7
-            image: ghcr.io/your-org/armv7-opencv:0.2.5
+            image: ghcr.io/your-org/armv7-opencv:0.2.7
             arch: armv7
 
     steps:
@@ -33,7 +33,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        run: cargo install cross --version 0.2.5 --locked
+        run: cargo install cross --version 0.2.7 --locked
 
       - name: Install cargo-deb
         if: github.event_name == 'release'

--- a/Cross.toml
+++ b/Cross.toml
@@ -8,4 +8,4 @@ xargo = false
 AR = "aarch64-linux-gnu-gcc-ar"
 
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/your-org/armv7-opencv:0.2.5"
+image = "ghcr.io/your-org/armv7-opencv:0.2.7"

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.7
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libopencv-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.5
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.7
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libopencv-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.7
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libopencv-dev:arm64 pkg-config ninja-build && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- bump cross-rs base images from `0.2.5` to `0.2.7`
- use the new tag in CI
- update `Cross.toml` image reference

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a38216f248321a1c13f136e6a9d79