### PR TITLE
Fix cross CLI install in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        run: cargo install cross --version 0.2.7 --locked
+        # 0.2.7 Docker images exist, but the CLI crate is still 0.2.6
+        # Pin to the latest published version until 0.2.7 lands on crates.io
+        run: cargo install cross --version 0.2.6 --locked
 
       - name: Install cargo-deb
         if: github.event_name == 'release'

--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ docker build -f Dockerfile.pi-opencv -t custom/aarch64-opencv .
 docker build -f Dockerfile.pi-opencv-armv7 -t custom/armv7-opencv .
 ```
 
-Install [`cross`](https://github.com/cross-rs/cross) and build using the image:
+Install [`cross`](https://github.com/cross-rs/cross) and build using the image.
+If the Docker image tag is newer than the latest crate on crates.io, pin the
+CLI to the published version:
 
 ```bash
-cargo install cross
+cargo install cross --version 0.2.6 --locked
 cross build --release --target aarch64-unknown-linux-gnu
 ```
 


### PR DESCRIPTION
## Summary
- pin the cross CLI to the latest published crate version
- document how to pin the version when the Docker image tag is newer

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683a3c0971a883219e423e690ba281f1