### PR TITLE
Update cross install instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        # 0.2.7 Docker images exist, but the CLI crate is still 0.2.6
-        # Pin to the latest published version until 0.2.7 lands on crates.io
-        run: cargo install cross --version 0.2.6 --locked
+        # The cross crate is no longer published on crates.io.
+        # Install straight from the repository and optionally lock to a tag.
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
 
       - name: Install cargo-deb
         if: github.event_name == 'release'

--- a/CROSS_INSTALL_TEMPLATE.txt
+++ b/CROSS_INSTALL_TEMPLATE.txt
@@ -1,0 +1,9 @@
+Cross CLI Installation
+
+The cross crate is no longer published on crates.io. Install it directly from the GitHub repository at https://github.com/cross-rs/cross.
+
+You may optionally lock to a tagged release such as v0.2.6 or v0.2.7. Using the default branch works as well.
+
+In your CI job, run a cargo install command with the --git option before any cross build commands.
+
+Remember that the Docker image tag does not need to match the CLI commit. They are independent.

--- a/README.md
+++ b/README.md
@@ -105,12 +105,14 @@ docker build -f Dockerfile.pi-opencv -t custom/aarch64-opencv .
 docker build -f Dockerfile.pi-opencv-armv7 -t custom/armv7-opencv .
 ```
 
-Install [`cross`](https://github.com/cross-rs/cross) and build using the image.
-If the Docker image tag is newer than the latest crate on crates.io, pin the
-CLI to the published version:
+Install [`cross`](https://github.com/cross-rs/cross) from the GitHub repository
+and build using the image. The crate is no longer published on crates.io, so the
+`--git` option must be used. You may lock to a tag such as `v0.2.6` or
+`v0.2.7`, but it is also fine to install from the default branch. The Docker
+image tag does not have to match the commit used for the CLI:
 
 ```bash
-cargo install cross --version 0.2.6 --locked
+cargo install cross --git https://github.com/cross-rs/cross --locked
 cross build --release --target aarch64-unknown-linux-gnu
 ```
 
@@ -131,7 +133,7 @@ native rustup). Clone the repository and run:
 ```bash
 git clone https://github.com/cropcrusaders/Rust-Spray.git
 cd Rust-Spray
-cargo install cross
+cargo install cross --git https://github.com/cross-rs/cross --locked
 cross build --release --target aarch64-unknown-linux-gnu
 ```
 


### PR DESCRIPTION
## Summary
- clarify cross is only installed from git
- provide template for cross install in CI
- document new cross install in README
- update workflow to install cross from repo

## Testing
- `cargo test --quiet` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683a3f126bf883219edc5dfa7df5f854