### PR TITLE
Fix CI for cross build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross
+      - name: Install cross CLI from Git
         # The cross crate is no longer published on crates.io.
-        # Install straight from the repository and optionally lock to a tag.
-        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+        # Install straight from the repository and lock dependencies.
+        run: cargo install --git https://github.com/cross-rs/cross --locked
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Install cargo-deb
         if: github.event_name == 'release'
@@ -90,3 +93,38 @@ jobs:
           asset_path: target/${{ matrix.target }}/debian/rustspray_*.deb
           asset_name: rustspray_${{ github.event.release.tag_name }}_${{ matrix.arch }}.deb
           asset_content_type: application/vnd.debian.binary-package
+
+  build-aarch64:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: "0.3.0"
+      DOCKERFILE_PATH: "docker/Dockerfile.aarch64"
+      GHCR_USER: "cropcrusaders"
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+      - name: Install cross CLI from Git
+        run: cargo install --git https://github.com/cross-rs/cross --locked
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: env.GHCR_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ env.GHCR_TOKEN }}
+      - name: Build ARM64 builder image
+        run: |
+          docker build \
+            -t ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }} \
+            -f ${{ env.DOCKERFILE_PATH }} .
+      - name: Run cross build using that image
+        run: |
+          cross build --release --target aarch64-unknown-linux-gnu \
+            --image ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }}

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge AS builder
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 
 # Install required dependencies for OpenCV
 # The base image occasionally contains an invalid Ubuntu mirror URL
@@ -43,7 +43,7 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
     cp /usr/local/lib/pkgconfig/opencv4.pc /aarch64-linux-gnu/lib/pkgconfig/
 
 # Final image: will be used by cross
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.6
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libopencv-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.6
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libopencv-dev:arm64 pkg-config ninja-build && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- update cross base images to `main`
- install cross from git in CI
- add Buildx setup and dedicated aarch64 build job

## Testing
- `cargo test` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a48b11fa88321b4f182611d1ef921