### PR TITLE
Fix cross CLI install command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install cross CLI from Git
         # The cross crate is no longer published on crates.io.
         # Install straight from the repository and lock dependencies.
-        run: cargo install --git https://github.com/cross-rs/cross --package cross --locked
+        run: cargo install --git https://github.com/cross-rs/cross cross --locked
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -109,7 +109,7 @@ jobs:
         with:
           targets: aarch64-unknown-linux-gnu
       - name: Install cross CLI from Git
-        run: cargo install --git https://github.com/cross-rs/cross --package cross --locked
+        run: cargo install --git https://github.com/cross-rs/cross cross --locked
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR


### PR DESCRIPTION
## Summary
- fix `cargo install` for cross CLI by specifying the crate name

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a532a233483218eb103e09deccee0