### PR TITLE
Fix cross CI configuration

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -4,8 +4,6 @@ image = "ghcr.io/cropcrusaders/aarch64-opencv:0.3.0"
 dockerfile = "docker/aarch64-opencv.dockerfile"
 xargo = false
 
-[target.aarch64-unknown-linux-gnu.env]
-AR = "aarch64-linux-gnu-gcc-ar"
 
 [target.armv7-unknown-linux-gnueabihf]
 image = "ghcr.io/your-org/armv7-opencv:0.2.6"

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.6
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libopencv-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- clean Cross config to work with newer cross versions
- fetch armv7 base image using the maintained tag

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_683a5573e164832193f4314441cd9c62