### PR TITLE
Fix multi-arch apt setup in Dockerfiles

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,4 +1,8 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libopencv-dev pkg-config && \
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libopencv-dev:armhf \
+        pkg-config:armhf \
+        ninja-build:armhf && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,5 +1,9 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libopencv-dev:arm64 pkg-config ninja-build && \
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libopencv-dev:arm64 \
+        pkg-config:arm64 \
+        ninja-build:arm64 && \
     rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- add target architectures in ARM docker images
- install arch-specific packages

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a5779182c832187f162c45d565ce1