### PR TITLE
Fix cross builder OpenCV install

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,8 +1,7 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN dpkg --add-architecture armhf && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        libopencv-dev:armhf \
-        pkg-config:armhf \
-        ninja-build:armhf && \
+        libopencv-dev \
+        pkg-config \
+        ninja-build && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,9 +1,8 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        libopencv-dev:arm64 \
-        pkg-config:arm64 \
-        ninja-build:arm64 && \
+        libopencv-dev \
+        pkg-config \
+        ninja-build && \
     rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- adjust cross-based dockerfiles to stop requesting arch-specific packages

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a5aa4dc488321b0e7ec2be4860791