### PR TITLE
Fix apt mirrors in Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -5,10 +5,11 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    apt-get update && \
-    apt-get install -y \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
       libgtk-3-dev \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
@@ -44,10 +45,11 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    apt-get update && \
-    apt-get install -y pkg-config
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
 ENV LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -8,10 +8,11 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    apt-get update && \
-    apt-get install -y \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
       libgtk-3-dev \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
@@ -47,10 +48,11 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    apt-get update && \
-    apt-get install -y pkg-config
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y pkg-config
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
 ENV LIBRARY_PATH=/usr/aarch64-linux-gnu/lib

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -8,10 +8,11 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    apt-get update && \
-    apt-get install -y \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
       libgtk-3-dev \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
@@ -47,10 +48,11 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|http://|https://|g' \
-            -e 's|archive.archive.ubuntu.com|archive.ubuntu.com|g' && \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    apt-get update && \
-    apt-get install -y pkg-config
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y pkg-config
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
 ENV LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,4 +1,8 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libopencv-dev pkg-config && \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y --no-install-recommends libopencv-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,6 +1,10 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \
         pkg-config \
         ninja-build && \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,6 +1,10 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i \
+            -e 's|archive.archive.ubuntu.com|ports.ubuntu.com|g' \
+            -e 's|security.archive.ubuntu.com|ports.ubuntu.com|g' && \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \
         pkg-config \
         ninja-build && \


### PR DESCRIPTION
## Summary
- avoid 403 errors by rewriting apt sources to `ports.ubuntu.com`
- retry apt operations to handle transient network failures

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a5d0dca248321b768a5e36eb4ad6e