### PR TITLE
Fix ARM builder apt mirrors

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -2,11 +2,13 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
 # Retry `apt-get update` to mitigate transient network issues
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
             printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
@@ -43,11 +45,13 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
             printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y pkg-config && \

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -5,11 +5,13 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 # ("archive.archive.ubuntu.com") which results in 403 errors during
 # package retrieval. Replace it with the correct mirror before running
 # `apt-get update`.
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
             printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
@@ -46,11 +48,13 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
             printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y pkg-config && \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -5,11 +5,13 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # ("archive.archive.ubuntu.com") which results in 403 errors during
 # package retrieval. Replace it with the correct mirror before running
 # `apt-get update`.
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
             printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
@@ -46,11 +48,13 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
             printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y pkg-config && \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,9 +1,11 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends libopencv-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,9 +1,11 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,9 +1,11 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|/ubuntu|/ubuntu-ports|g' && \
+RUN find /etc/apt -name '*.list' -print0 | while IFS= read -r -d '' file; do \
+        sed -i 's|archive.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|security.ubuntu.com|ports.ubuntu.com|g' "$file"; \
+        sed -i 's|/ubuntu-ports-ports|/ubuntu-ports|g' "$file"; \
+        sed -i -e 's|/ubuntu\([ /]\)|/ubuntu-ports\1|g' "$file"; \
+        sed -i -e 's|/ubuntu$|/ubuntu-ports|' "$file"; \
+    done && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \


### PR DESCRIPTION
## Summary
- repair Ubuntu mirror rewriting so the ARM builder images use `ports.ubuntu.com/ubuntu-ports`
- remove any duplicate `ubuntu-ports` segments before updating package lists

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a61f0b2fc83218da16e626e83ceb6