### PR TITLE
Fix apt sources for arm images

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -4,8 +4,8 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # Retry `apt-get update` to mitigate transient network issues
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
@@ -44,8 +44,8 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -7,8 +7,8 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 # `apt-get update`.
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
@@ -47,8 +47,8 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -7,8 +7,8 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # `apt-get update`.
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
@@ -47,8 +47,8 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,8 +1,8 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev pkg-config && \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,8 +1,8 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com|ports.ubuntu.com|g' \
-            -e 's|security.ubuntu.com|ports.ubuntu.com|g' && \
+            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev \


### PR DESCRIPTION
## Summary
- rewrite apt sources directly to ports.ubuntu.com/ubuntu-ports
- avoid archive.ports and security.ports 404s

## Testing
- `cargo test --quiet` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a6baccc988321af9cb6fa6ae91283