### PR TITLE
Update APT mirrors for arm builds

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -2,7 +2,9 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev pkg-config && \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -2,7 +2,9 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
 RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
+            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
+            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev \


### PR DESCRIPTION
## Summary
- adjust mirror rewriting in `Dockerfile.armv7` and `Dockerfile.aarch64` to drop erroneous `archive.`/`security.` prefixes

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a6f268e2483218ebe81b142d20409