### PR TITLE
Fix duplicate apt sources in cross Dockerfiles

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -4,8 +4,10 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' && \
-    apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
-        libopencv-dev pkg-config && \
+            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
+    && rm -f /etc/apt/sources.list.d/ports.list \
+    && apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
+        libopencv-dev pkg-config \
+    && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -4,10 +4,12 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' && \
-    apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
+            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
+    && rm -f /etc/apt/sources.list.d/ports.list \
+    && apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev \
         pkg-config \
-        ninja-build && \
+        ninja-build \
+    && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- adjust the cross build Dockerfiles to delete the temporary `ports.list`
- keep a single apt sources file before installing dependencies

## Testing
- `cargo test --locked --all-targets` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a7266230c8321a5b6fc7c21897359