### PR TITLE
Fix apt 404s in Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -7,6 +7,10 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    dpkg --remove-architecture i386 && \
+    dpkg --remove-architecture amd64 && \
+    find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
       pkg-config \

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -10,6 +10,10 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    dpkg --remove-architecture i386 && \
+    dpkg --remove-architecture amd64 && \
+    find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
       pkg-config \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -10,6 +10,10 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    dpkg --remove-architecture i386 && \
+    dpkg --remove-architecture amd64 && \
+    find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
       pkg-config \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -6,6 +6,12 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
     && rm -f /etc/apt/sources.list.d/ports.list \
+    # Drop architectures that are unsupported on ports.ubuntu.com
+    && dpkg --remove-architecture i386 \
+    && dpkg --remove-architecture amd64 \
+    # Restrict repository components to main and universe only
+    && find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev pkg-config \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -6,6 +6,12 @@ RUN find /etc/apt -name '*.list' -print0 \
             -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
     && rm -f /etc/apt/sources.list.d/ports.list \
+    # Drop architectures that have no indexes on ports.ubuntu.com
+    && dpkg --remove-architecture i386 \
+    && dpkg --remove-architecture amd64 \
+    # Only keep the main and universe components to avoid 404 errors
+    && find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -3,6 +3,11 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
+    # Remove unsupported architectures and unused repository sections
+    dpkg --remove-architecture i386 && \
+    dpkg --remove-architecture amd64 && \
+    find /etc/apt -name '*.list' -print0 \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
         libopencv-dev \


### PR DESCRIPTION
## Summary
- trim unsupported architectures from apt configuration
- drop `restricted` and `multiverse` components when using ports.ubuntu.com

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a74b3dd8c8321a1bf7e286200447e