### PR TITLE
Fix apt source lines in Dockerfiles

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -9,8 +9,13 @@ RUN find /etc/apt -name '*.list' -print0 \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     dpkg --remove-architecture i386 && \
     dpkg --remove-architecture amd64 && \
+    # Removing "restricted" and "multiverse" can leave lines without components
+    # after the architecture field. APT reports "Malformed entry ... (Component)"
+    # unless each line ends with at least one component. Rewrite the active
+    # entries to always end with "main universe".
     find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
+            -e 's|^\(deb[^ ]*\(\s\+\[[^]]\+\]\)?\s\+[^ ]\+\s\+[^ ]\+\)\s\+.*|\1 main universe|' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
       pkg-config \

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -12,8 +12,13 @@ RUN find /etc/apt -name '*.list' -print0 \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     dpkg --remove-architecture i386 && \
     dpkg --remove-architecture amd64 && \
+    # Removing the words "restricted" and "multiverse" can leave some sources
+    # lines empty after the architecture field which triggers the error
+    # "Malformed entry ... (Component)". Rewrite each active mirror line so it
+    # ends with exactly "main universe" to keep APT happy.
     find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
+            -e 's|^\(deb[^ ]*\(\s\+\[[^]]\+\]\)?\s\+[^ ]\+\s\+[^ ]\+\)\s\+.*|\1 main universe|' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
       pkg-config \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -12,8 +12,12 @@ RUN find /etc/apt -name '*.list' -print0 \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     dpkg --remove-architecture i386 && \
     dpkg --remove-architecture amd64 && \
+    # Removing "restricted" and "multiverse" may leave sources lines empty after
+    # the architecture field which results in "Malformed entry ... (Component)".
+    # Rewrite them so every active line ends with "main universe".
     find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
+        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
+            -e 's|^\(deb[^ ]*\(\s\+\[[^]]\+\]\)?\s\+[^ ]\+\s\+[^ ]\+\)\s\+.*|\1 main universe|' && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y \
       pkg-config \


### PR DESCRIPTION
## Summary
- avoid `Malformed entry` apt errors in Dockerfiles
- rewrite mirror lines to end with `main universe`
- document the root cause in comments

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a78b7716c83218abbc515222f9ca3