### PR TITLE
Fix apt sources for ARM builds

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -1,23 +1,14 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
-# Retry `apt-get update` to mitigate transient network issues
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    dpkg --remove-architecture i386 && \
-    dpkg --remove-architecture amd64 && \
-    # Removing "restricted" and "multiverse" can leave lines without components
-    # after the architecture field. APT reports "Malformed entry ... (Component)"
-    # unless each line ends with at least one component. Rewrite the active
-    # entries to always end with "main universe".
-    find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
-            -e 's|^\(deb[^ ]*\(\s\+\[[^]]\+\]\)?\s\+[^ ]\+\s\+[^ ]\+\)\s\+.*|\1 main universe|' && \
+RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y \
+    apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
       libgtk-3-dev \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,26 +1,15 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 
 # Install required dependencies for OpenCV
-# The base image occasionally contains an invalid Ubuntu mirror URL
-# ("archive.archive.ubuntu.com") which results in 403 errors during
-# package retrieval. Replace it with the correct mirror before running
-# `apt-get update`.
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    dpkg --remove-architecture i386 && \
-    dpkg --remove-architecture amd64 && \
-    # Removing the words "restricted" and "multiverse" can leave some sources
-    # lines empty after the architecture field which triggers the error
-    # "Malformed entry ... (Component)". Rewrite each active mirror line so it
-    # ends with exactly "main universe" to keep APT happy.
-    find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
-            -e 's|^\(deb[^ ]*\(\s\+\[[^]]\+\]\)?\s\+[^ ]\+\s\+[^ ]\+\)\s\+.*|\1 main universe|' && \
+# Replace all existing sources with a minimal list from ports.ubuntu.com
+RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y \
+    apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
       libgtk-3-dev \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -1,25 +1,15 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
-# The base image occasionally contains an invalid Ubuntu mirror URL
-# ("archive.archive.ubuntu.com") which results in 403 errors during
-# package retrieval. Replace it with the correct mirror before running
-# `apt-get update`.
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    dpkg --remove-architecture i386 && \
-    dpkg --remove-architecture amd64 && \
-    # Removing "restricted" and "multiverse" may leave sources lines empty after
-    # the architecture field which results in "Malformed entry ... (Component)".
-    # Rewrite them so every active line ends with "main universe".
-    find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
-            -e 's|^\(deb[^ ]*\(\s\+\[[^]]\+\]\)?\s\+[^ ]\+\s\+[^ ]\+\)\s\+.*|\1 main universe|' && \
+# Replace existing sources with a minimal list from ports.ubuntu.com
+RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y \
+    apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
       libgtk-3-dev \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,19 +1,10 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
-    && rm -f /etc/apt/sources.list.d/ports.list \
-    # Drop architectures that are unsupported on ports.ubuntu.com
-    && dpkg --remove-architecture i386 \
-    && dpkg --remove-architecture amd64 \
-    # Restrict repository components to main and universe only
-    && find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
+RUN printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+        > /etc/apt/sources.list \
     && apt-get -o Acquire::Retries=3 update \
-    && apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev pkg-config \
-    && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,21 +1,12 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|archive.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ports.ubuntu.com/ubuntu-ports|ports.ubuntu.com/ubuntu-ports|g' \
-    && rm -f /etc/apt/sources.list.d/ports.list \
-    # Drop architectures that have no indexes on ports.ubuntu.com
-    && dpkg --remove-architecture i386 \
-    && dpkg --remove-architecture amd64 \
-    # Only keep the main and universe components to avoid 404 errors
-    && find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' \
+RUN printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+        > /etc/apt/sources.list \
     && apt-get -o Acquire::Retries=3 update \
-    && apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \
         pkg-config \
         ninja-build \
-    && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,17 +1,13 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    # Remove unsupported architectures and unused repository sections
-    dpkg --remove-architecture i386 && \
-    dpkg --remove-architecture amd64 && \
-    find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i -e 's/ restricted//g' -e 's/ multiverse//g' && \
-    apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y --no-install-recommends \
+RUN printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+        'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+        > /etc/apt/sources.list \
+    && apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \
         pkg-config \
-        ninja-build && \
-    rm -rf /var/lib/apt/lists/*
+        ninja-build \
+    && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- replace mirror rewriting with clean sources.list
- simplify build Dockerfiles for ARMv7 and AArch64

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a7cf7acf48321b8cfc5fbbdee74eb