### PR TITLE
Fix apt sources for ports mirror

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -2,11 +2,15 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
 RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    rm -f /etc/apt/sources.list.d/ports.list && \
     printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
+    dpkg --remove-architecture amd64 || true && \
+    dpkg --remove-architecture i386 || true && \
+    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -46,7 +50,11 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
+    rm -f /etc/apt/sources.list.d/ports.list && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    dpkg --remove-architecture amd64 || true && \
+    dpkg --remove-architecture i386 || true && \
+    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -3,11 +3,15 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 # Install required dependencies for OpenCV
 # Replace all existing sources with a minimal list from ports.ubuntu.com
 RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    rm -f /etc/apt/sources.list.d/ports.list && \
     printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
+    dpkg --remove-architecture amd64 || true && \
+    dpkg --remove-architecture i386 || true && \
+    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -47,7 +51,11 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
+    rm -f /etc/apt/sources.list.d/ports.list && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    dpkg --remove-architecture amd64 || true && \
+    dpkg --remove-architecture i386 || true && \
+    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -3,11 +3,15 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # Install required dependencies for OpenCV
 # Replace existing sources with a minimal list from ports.ubuntu.com
 RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    rm -f /etc/apt/sources.list.d/ports.list && \
     printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
+    dpkg --remove-architecture amd64 || true && \
+    dpkg --remove-architecture i386 || true && \
+    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -47,7 +51,11 @@ RUN find /etc/apt -name '*.list' -print0 \
         | xargs -0 sed -i \
             -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
             -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
+    rm -f /etc/apt/sources.list.d/ports.list && \
     printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
+    dpkg --remove-architecture amd64 || true && \
+    dpkg --remove-architecture i386 || true && \
+    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,9 +1,13 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-        > /etc/apt/sources.list \
+RUN rm -f /etc/apt/sources.list.d/ports.list \
+    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list \
+    && dpkg --remove-architecture amd64 || true \
+    && dpkg --remove-architecture i386 || true \
+    && test -z "$(dpkg --print-foreign-architectures)" \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev pkg-config \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,9 +1,13 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-        > /etc/apt/sources.list \
+RUN rm -f /etc/apt/sources.list.d/ports.list \
+    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list \
+    && dpkg --remove-architecture amd64 || true \
+    && dpkg --remove-architecture i386 || true \
+    && test -z "$(dpkg --print-foreign-architectures)" \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,9 +1,13 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-        'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-        > /etc/apt/sources.list \
+RUN rm -f /etc/apt/sources.list.d/ports.list \
+    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list \
+    && dpkg --remove-architecture amd64 || true \
+    && dpkg --remove-architecture i386 || true \
+    && test -z "$(dpkg --print-foreign-architectures)" \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \


### PR DESCRIPTION
## Summary
- clean up old apt mirror lists in all Dockerfiles
- remove unsupported foreign architectures before installing packages
- reinstall required packages from ports.ubuntu.com

## Testing
- `cargo test --locked` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a7f6f63988321885eb4410e343f4b