### PR TITLE
Fix apt sources for arm builds

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -3,11 +3,12 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # Install required dependencies for OpenCV
 RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
+    dpkg --add-architecture armhf || true && \
     dpkg --remove-architecture amd64 || true && \
     dpkg --remove-architecture i386 || true && \
     test -z "$(dpkg --print-foreign-architectures)" && \

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -4,11 +4,12 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 # Replace all existing sources with a minimal list from ports.ubuntu.com
 RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
+    dpkg --add-architecture arm64 || true && \
     dpkg --remove-architecture amd64 || true && \
     dpkg --remove-architecture i386 || true && \
     test -z "$(dpkg --print-foreign-architectures)" && \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -4,11 +4,12 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 # Replace existing sources with a minimal list from ports.ubuntu.com
 RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
     rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
+    dpkg --add-architecture armhf || true && \
     dpkg --remove-architecture amd64 || true && \
     dpkg --remove-architecture i386 || true && \
     test -z "$(dpkg --print-foreign-architectures)" && \

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,10 +1,11 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN rm -f /etc/apt/sources.list.d/ports.list \
-    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list \
+    && dpkg --add-architecture arm64 || true \
     && dpkg --remove-architecture amd64 || true \
     && dpkg --remove-architecture i386 || true \
     && test -z "$(dpkg --print-foreign-architectures)" \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,10 +1,11 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
 RUN rm -f /etc/apt/sources.list.d/ports.list \
-    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list \
+    && dpkg --add-architecture armhf || true \
     && dpkg --remove-architecture amd64 || true \
     && dpkg --remove-architecture i386 || true \
     && test -z "$(dpkg --print-foreign-architectures)" \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,10 +1,11 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
 RUN rm -f /etc/apt/sources.list.d/ports.list \
-    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list \
+    && dpkg --add-architecture arm64 || true \
     && dpkg --remove-architecture amd64 || true \
     && dpkg --remove-architecture i386 || true \
     && test -z "$(dpkg --print-foreign-architectures)" \


### PR DESCRIPTION
## Summary
- ensure apt uses arm-specific indexes in custom Docker images
- add target architectures to dpkg configuration to avoid amd64 requests

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a824683cc832180d7ed326e8f2f30