### PR TITLE
Fix cross docker sources and workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,6 @@ jobs:
           docker build \
             -t ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }} \
             -f ${{ env.DOCKERFILE_PATH }} .
-      - name: Run cross build using that image
+      - name: Run cross build
         run: |
-          cross build --release --target aarch64-unknown-linux-gnu \
-            --image ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }}
+          cross build --release --target aarch64-unknown-linux-gnu

--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -1,17 +1,12 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
-RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
-    dpkg --add-architecture armhf || true && \
-    dpkg --remove-architecture amd64 || true && \
-    dpkg --remove-architecture i386 || true && \
-    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -47,15 +42,12 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    dpkg --remove-architecture amd64 || true && \
-    dpkg --remove-architecture i386 || true && \
-    test -z "$(dpkg --print-foreign-architectures)" && \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -2,15 +2,12 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
 
 # Install required dependencies for OpenCV
 # Replace all existing sources with a minimal list from ports.ubuntu.com
-RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
-    dpkg --remove-architecture amd64 || true && \
-    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -46,15 +43,12 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    dpkg --remove-architecture amd64 || true && \
-    dpkg --remove-architecture i386 || true && \
-    test -z "$(dpkg --print-foreign-architectures)" && \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -2,17 +2,12 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
 # Install required dependencies for OpenCV
 # Replace existing sources with a minimal list from ports.ubuntu.com
-RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list && \
-    dpkg --add-architecture armhf || true && \
-    dpkg --remove-architecture amd64 || true && \
-    dpkg --remove-architecture i386 || true && \
-    test -z "$(dpkg --print-foreign-architectures)" && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -48,15 +43,12 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN find /etc/apt -name '*.list' -print0 \
-        | xargs -0 sed -i \
-            -e 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' \
-            -e 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|g' && \
-    rm -f /etc/apt/sources.list.d/ports.list && \
-    printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::Retries "5";\n' > /etc/apt/apt.conf.d/99ci && \
-    dpkg --remove-architecture amd64 || true && \
-    dpkg --remove-architecture i386 || true && \
-    test -z "$(dpkg --print-foreign-architectures)" && \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,13 +1,12 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN rm -f /etc/apt/sources.list.d/ports.list \
-    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+RUN rm -rf /etc/apt/sources.list.d/* \
+    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list \
-    && dpkg --remove-architecture amd64 || true \
-    && dpkg --remove-architecture i386 || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-        libopencv-dev pkg-config \
+        libopencv-dev \
+        pkg-config \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,14 +1,10 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN rm -f /etc/apt/sources.list.d/ports.list \
-    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+RUN rm -rf /etc/apt/sources.list.d/* \
+    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list \
-    && dpkg --add-architecture armhf || true \
-    && dpkg --remove-architecture amd64 || true \
-    && dpkg --remove-architecture i386 || true \
-    && test -z "$(dpkg --print-foreign-architectures)" \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,16 +1,13 @@
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN rm -f /etc/apt/sources.list.d/ports.list \
-    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+RUN rm -rf /etc/apt/sources.list.d/* \
+    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
            > /etc/apt/sources.list \
-    && dpkg --remove-architecture amd64 || true \
-    && dpkg --remove-architecture i386 || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev \
         pkg-config \
-        ninja-build \
     && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- clean up apt sources in dockerfiles for arm
- build with `cross` without using `--image`

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683a8b7b134c8321bb1592e01a45aea0