### PR TITLE
Fix cross install for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install cross
         run: |
-          cargo install cross --locked
+          cargo install --git https://github.com/cross-rs/cross cross --locked
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Build for aarch64


### PR DESCRIPTION
## Summary
- install cross from GitHub in release workflow

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_683a9059ee6083219174007c09f1d66f