### PR TITLE
Update ARM CI images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,10 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            dockerfile: docker/Dockerfile.aarch64
-            image: ghcr.io/cropcrusaders/aarch64-opencv:0.3.0
+            image: ghcr.io/your-org/aarch64-opencv:latest
             arch: arm64
           - target: armv7-unknown-linux-gnueabihf
-            dockerfile: docker/Dockerfile.armv7
-            image: ghcr.io/your-org/armv7-opencv:0.2.6
+            image: ghcr.io/your-org/armv7-opencv:latest
             arch: armv7
             continue-on-error: true
 
@@ -49,24 +47,8 @@ jobs:
         if: github.event_name == 'release'
         run: cargo install cargo-deb --locked
 
-      - name: Restore cached cross image
-        id: cache-cross
-        uses: actions/cache@v3
-        with:
-          path: cross-image-${{ matrix.arch }}.tar
-          key: ${{ runner.os }}-${{ matrix.image }}-${{ hashFiles(matrix.dockerfile) }}
-
-      - name: Load cross image
-        if: steps.cache-cross.outputs.cache-hit == 'true'
-        run: docker load -i cross-image-${{ matrix.arch }}.tar
-
-      - name: Build custom cross image
-        if: steps.cache-cross.outputs.cache-hit != 'true'
-        run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
-
-      - name: Save cross image
-        if: steps.cache-cross.outputs.cache-hit != 'true'
-        run: docker save ${{ matrix.image }} -o cross-image-${{ matrix.arch }}.tar
+      - name: Pull cross image
+        run: docker pull ${{ matrix.image }}
 
       - name: +8 GB swap to survive clang
         uses: pierotofy/set-swap-space@v1.0
@@ -102,9 +84,9 @@ jobs:
   build-aarch64:
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: "0.3.0"
+      IMAGE_TAG: "latest"
       DOCKERFILE_PATH: "docker/Dockerfile.aarch64"
-      GHCR_USER: "cropcrusaders"
+      GHCR_USER: "your-org"
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     steps:
       - name: Checkout
@@ -130,8 +112,11 @@ jobs:
       - name: Build ARM64 builder image
         run: |
           docker build \
-            -t ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }} \
+            -t ghcr.io/your-org/aarch64-opencv:${{ env.IMAGE_TAG }} \
             -f ${{ env.DOCKERFILE_PATH }} .
+      - name: Push image
+        if: env.GHCR_TOKEN != ''
+        run: docker push ghcr.io/your-org/aarch64-opencv:${{ env.IMAGE_TAG }}
       - name: Run cross build
         run: |
           cross build --release --target aarch64-unknown-linux-gnu

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,9 +1,9 @@
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/cropcrusaders/aarch64-opencv:0.3.0"
+image = "ghcr.io/your-org/aarch64-opencv:latest"
 dockerfile = "docker/aarch64-opencv.dockerfile"
 xargo = false
 
 
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/your-org/armv7-opencv:0.2.6"
+image = "ghcr.io/your-org/armv7-opencv:latest"

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -1,13 +1,8 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS builder
+FROM ubuntu:22.04 AS builder
 
 # Install required dependencies for OpenCV
-# Replace all existing sources with a minimal list from ports.ubuntu.com
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list && \
+RUN dpkg --add-architecture arm64 && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -42,13 +37,9 @@ RUN mkdir -p /aarch64-linux-gnu/lib && \
     cp /usr/local/lib/pkgconfig/opencv4.pc /aarch64-linux-gnu/lib/pkgconfig/
 
 # Final image: will be used by cross
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list && \
+FROM ubuntu:22.04
+RUN dpkg --add-architecture arm64 && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -1,13 +1,8 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
+FROM ubuntu:22.04 AS builder
 
 # Install required dependencies for OpenCV
-# Replace existing sources with a minimal list from ports.ubuntu.com
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list && \
+RUN dpkg --add-architecture armhf && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config \
@@ -42,13 +37,9 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
     cp /usr/local/lib/pkgconfig/opencv4.pc /arm-linux-gnueabihf/lib/pkgconfig/
 
 # Final image: will be used by cross
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list && \
+FROM ubuntu:22.04
+RUN dpkg --add-architecture armhf && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ If you prefer to build inside a container you can create the images used by
 
 ```bash
 # For 64-bit ARM targets
-docker build -f Dockerfile.pi-opencv -t custom/aarch64-opencv .
+docker build -f Dockerfile.pi-opencv -t ghcr.io/your-org/aarch64-opencv:latest .
 
 # For 32-bit ARM targets
-docker build -f Dockerfile.pi-opencv-armv7 -t custom/armv7-opencv .
+docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/your-org/armv7-opencv:latest .
 ```
 
 Install [`cross`](https://github.com/cross-rs/cross) from the GitHub repository
@@ -120,7 +120,8 @@ Replace the target as needed. You can also run arbitrary commands inside the
 image, for example:
 
 ```bash
-docker run --rm -it -v $(pwd):/project -w /project custom/aarch64-opencv cargo test
+docker run --rm -it -v $(pwd):/project -w /project \
+  ghcr.io/your-org/aarch64-opencv:latest cargo test
 ```
 
 ### Windows

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,12 +1,11 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN rm -rf /etc/apt/sources.list.d/* \
-    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list \
+FROM ubuntu:22.04
+
+# Enable the ARM64 architecture and remove unnecessary ones
+RUN dpkg --add-architecture arm64 \
+    && dpkg --remove-architecture i386 || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-        libopencv-dev \
-        pkg-config \
+        libopencv-dev:arm64 \
+        pkg-config:arm64 \
+        ninja-build:arm64 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,13 +1,11 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
-RUN rm -rf /etc/apt/sources.list.d/* \
-    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list \
+FROM ubuntu:22.04
+
+# Enable the ARMHF architecture and clean up unused ones
+RUN dpkg --add-architecture armhf \
+    && dpkg --remove-architecture i386 || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-        libopencv-dev \
-        pkg-config \
-        ninja-build \
+        libopencv-dev:armhf \
+        pkg-config:armhf \
+        ninja-build:armhf \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,13 +1,12 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-RUN rm -rf /etc/apt/sources.list.d/* \
-    && printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
-           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
-           > /etc/apt/sources.list \
+FROM ubuntu:22.04
+
+# Enable the ARM64 architecture and clean up unused ones
+RUN dpkg --add-architecture arm64 \
+    && dpkg --remove-architecture i386 || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-        libopencv-dev \
-        pkg-config \
+        libopencv-dev:arm64 \
+        pkg-config:arm64 \
+        ninja-build:arm64 \
     && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- build ARM images on Ubuntu 22.04
- publish builder images and pull them in CI
- update Cross configuration to use GHCR images
- document new image tags in README

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a93ff7c6c83218fad5d2512a1e90c