### PR TITLE
Update ARM dockerfiles for proper packages

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -3,6 +3,12 @@ FROM ubuntu:22.04
 # Enable the ARM64 architecture and remove unnecessary ones
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
+    && sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
+    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted\n' \
+             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted\n' \
+             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted\n' \
+             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted\n' \
+             > /etc/apt/sources.list.d/arm64.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -3,6 +3,12 @@ FROM ubuntu:22.04
 # Enable the ARMHF architecture and clean up unused ones
 RUN dpkg --add-architecture armhf \
     && dpkg --remove-architecture i386 || true \
+    && sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
+    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main restricted\n' \
+             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted\n' \
+             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted\n' \
+             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted\n' \
+             > /etc/apt/sources.list.d/armhf.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:armhf \


### PR DESCRIPTION
## Summary
- fix ARM package setup in docker/Dockerfile.aarch64
- fix ARM package setup in docker/Dockerfile.armv7

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683a9cc6059c832184fb188d19dc00b1