### PR TITLE
Fix ARM apt sources

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -4,10 +4,10 @@ FROM ubuntu:22.04
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
     && sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
-    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted\n' \
-             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted\n' \
-             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted\n' \
-             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted\n' \
+    && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' \
+             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' \
+             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' \
+             'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main universe restricted\n' \
              > /etc/apt/sources.list.d/arm64.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -4,10 +4,10 @@ FROM ubuntu:22.04
 RUN dpkg --add-architecture armhf \
     && dpkg --remove-architecture i386 || true \
     && sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
-    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted\n' \
+    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' \
+             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' \
+             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' \
+             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main universe restricted\n' \
              > /etc/apt/sources.list.d/armhf.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- add `universe` to ARM sources in Dockerfiles to ensure libopencv-dev can be resolved

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_683a9ed06d148321b5e50e100967116a