### PR TITLE
Add libunwind for ROS builds

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -5,12 +5,13 @@ RUN dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
-      pkg-config \
-      libgtk-3-dev \
-      libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
-      libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
-      openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
-      libdc1394-dev cmake git clang && \
+        pkg-config \
+        libgtk-3-dev \
+        libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+        libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
+        openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
+        libunwind-dev \
+        libdc1394-dev cmake git clang && \
     rm -rf /var/lib/apt/lists/*
 
 # Build and install OpenCV for ARM64

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -5,12 +5,13 @@ RUN dpkg --add-architecture armhf && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
-      pkg-config \
-      libgtk-3-dev \
-      libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
-      libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
-      openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
-      libdc1394-dev cmake git clang && \
+        pkg-config \
+        libgtk-3-dev \
+        libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+        libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
+        openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
+        libunwind-dev \
+        libdc1394-dev cmake git clang && \
     rm -rf /var/lib/apt/lists/*
 
 # Build and install OpenCV for ARMv7

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ docker build -f Dockerfile.pi-opencv -t ghcr.io/your-org/aarch64-opencv:latest .
 docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/your-org/armv7-opencv:latest .
 ```
 
+These Dockerfiles install common build tools and now include
+`libunwind-dev` for the target architecture. This resolves missing
+dependencies when building ROS 2 packages such as `nav2` inside the
+container.
+
 Install [`cross`](https://github.com/cross-rs/cross) from the GitHub repository
 and build using the image. The crate is no longer published on crates.io, so the
 `--git` option must be used. You may lock to a tag such as `v0.2.6` or

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -12,6 +12,7 @@ RUN dpkg --add-architecture arm64 \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \
+        libunwind-dev:arm64 \
         pkg-config:arm64 \
         ninja-build:arm64 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -12,6 +12,7 @@ RUN dpkg --add-architecture armhf \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:armhf \
+        libunwind-dev:armhf \
         pkg-config:armhf \
         ninja-build:armhf \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- include `libunwind-dev` in all Dockerfiles
- document ROS dependency in README

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bae6f72b08321a7e578d175282a1d