### PR TITLE
Add FFmpeg libs and build armv7 Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    needs: [build-aarch64, build-armv7]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -120,3 +121,32 @@ jobs:
       - name: Run cross build
         run: |
           cross build --release --target aarch64-unknown-linux-gnu
+
+  build-armv7:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: "latest"
+      DOCKERFILE_PATH: "docker/Dockerfile.armv7"
+      GHCR_USER: "your-org"
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU (needed for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: env.GHCR_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ env.GHCR_TOKEN }}
+      - name: Build ARMv7 builder image
+        run: |
+          docker build \
+            -t ghcr.io/your-org/armv7-opencv:${{ env.IMAGE_TAG }} \
+            -f ${{ env.DOCKERFILE_PATH }} .
+      - name: Push image
+        if: env.GHCR_TOKEN != ''
+        run: docker push ghcr.io/your-org/armv7-opencv:${{ env.IMAGE_TAG }}

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -12,6 +12,10 @@ RUN dpkg --add-architecture arm64 \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \
+        libavcodec-dev:arm64 \
+        libavformat-dev:arm64 \
+        libavutil-dev:arm64 \
+        libswscale-dev:arm64 \
         libunwind-dev:arm64 \
         pkg-config:arm64 \
         ninja-build:arm64 \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,18 +1,31 @@
-FROM ubuntu:22.04
+# ---------- build stage: fetch all the right armhf libs ----------
+FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
-# Enable the ARMHF architecture and clean up unused ones
-RUN dpkg --add-architecture armhf \
-    && dpkg --remove-architecture i386 || true \
-    && sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
-    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main universe restricted\n' \
-             > /etc/apt/sources.list.d/armhf.list \
-    && apt-get -o Acquire::Retries=3 update \
-    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-        libopencv-dev:armhf \
-        libunwind-dev:armhf \
+# Enable armhf architecture and Universe repo (where libav* lives)
+RUN dpkg --add-architecture armhf && \
+    sed -Ei 's/^# deb-src/deb-src/' /etc/apt/sources.list && \
+    add-apt-repository universe && \
+    apt-get update
+
+# Pull in OpenCV and FFmpeg *dev* packages for armhf
+RUN apt-get install -y --no-install-recommends \
+        gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         pkg-config:armhf \
-        ninja-build:armhf \
-    && rm -rf /var/lib/apt/lists/*
+        libopencv-dev:armhf \
+        libavcodec-dev:armhf \
+        libavformat-dev:armhf \
+        libavutil-dev:armhf \
+        libswscale-dev:armhf
+
+# ---------- final stage: image that cross will mount as sysroot ----------
+FROM --platform=linux/arm/v7 ubuntu:22.04
+
+# copy the entire armhf sysroot we just populated
+COPY --from=pkgstage /usr/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/
+COPY --from=pkgstage /usr/lib/arm-linux-gnueabihf/ /usr/lib/arm-linux-gnueabihf/
+COPY --from=pkgstage /usr/include/arm-linux-gnueabihf/ /usr/include/arm-linux-gnueabihf/
+
+# make pkg-config aware of the armhf .pc files
+ENV PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig
+
+# nothing else needed – this is a “sysroot only” image for cross-rs


### PR DESCRIPTION
## Summary
- add missing FFmpeg libs to the ARM builder Dockerfiles
- provide minimal sysroot Dockerfile for armv7
- build & push armv7 Docker image in CI
- wait for arm builds before running matrix

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bb3795ee883219b4721cb97967549