### PR TITLE
Fix cross images for ARM builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,18 +10,18 @@ on:
 
 jobs:
   build:
+    needs: [build-aarch64, build-armv7]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            image: ghcr.io/your-org/aarch64-opencv:latest
+            image: ghcr.io/cropcrusaders/aarch64-opencv:latest
             arch: arm64
           - target: armv7-unknown-linux-gnueabihf
-            image: ghcr.io/your-org/armv7-opencv:latest
+            image: ghcr.io/cropcrusaders/armv7-opencv:latest
             arch: armv7
-            continue-on-error: true
 
     steps:
       - name: Checkout
@@ -86,7 +86,7 @@ jobs:
     env:
       IMAGE_TAG: "latest"
       DOCKERFILE_PATH: "docker/Dockerfile.aarch64"
-      GHCR_USER: "your-org"
+      GHCR_USER: "cropcrusaders"
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     steps:
       - name: Checkout
@@ -112,11 +112,40 @@ jobs:
       - name: Build ARM64 builder image
         run: |
           docker build \
-            -t ghcr.io/your-org/aarch64-opencv:${{ env.IMAGE_TAG }} \
+            -t ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }} \
             -f ${{ env.DOCKERFILE_PATH }} .
       - name: Push image
         if: env.GHCR_TOKEN != ''
-        run: docker push ghcr.io/your-org/aarch64-opencv:${{ env.IMAGE_TAG }}
+        run: docker push ghcr.io/cropcrusaders/aarch64-opencv:${{ env.IMAGE_TAG }}
       - name: Run cross build
         run: |
           cross build --release --target aarch64-unknown-linux-gnu
+
+  build-armv7:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: "latest"
+      DOCKERFILE_PATH: "docker/Dockerfile.armv7"
+      GHCR_USER: "cropcrusaders"
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU (needed for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: env.GHCR_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ env.GHCR_TOKEN }}
+      - name: Build ARMv7 builder image
+        run: |
+          docker build \
+            -t ghcr.io/cropcrusaders/armv7-opencv:${{ env.IMAGE_TAG }} \
+            -f ${{ env.DOCKERFILE_PATH }} .
+      - name: Push image
+        if: env.GHCR_TOKEN != ''
+        run: docker push ghcr.io/cropcrusaders/armv7-opencv:${{ env.IMAGE_TAG }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,9 +1,9 @@
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/your-org/aarch64-opencv:latest"
+image = "ghcr.io/cropcrusaders/aarch64-opencv:latest"
 dockerfile = "docker/aarch64-opencv.dockerfile"
 xargo = false
 
 
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/your-org/armv7-opencv:latest"
+image = "ghcr.io/cropcrusaders/armv7-opencv:latest"

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ If you prefer to build inside a container you can create the images used by
 
 ```bash
 # For 64-bit ARM targets
-docker build -f Dockerfile.pi-opencv -t ghcr.io/your-org/aarch64-opencv:latest .
+docker build -f Dockerfile.pi-opencv -t ghcr.io/cropcrusaders/aarch64-opencv:latest .
 
 # For 32-bit ARM targets
-docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/your-org/armv7-opencv:latest .
+docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/cropcrusaders/armv7-opencv:latest .
 ```
 
 These Dockerfiles install common build tools and now include
@@ -126,7 +126,7 @@ image, for example:
 
 ```bash
 docker run --rm -it -v $(pwd):/project -w /project \
-  ghcr.io/your-org/aarch64-opencv:latest cargo test
+  ghcr.io/cropcrusaders/aarch64-opencv:latest cargo test
 ```
 
 An all-in-one Dockerfile named `Dockerfile.cross-aarch64` is provided for
@@ -134,7 +134,7 @@ convenience. It builds OpenCV from source and then cross-compiles the project
 for `aarch64-unknown-linux-gnu` in a single multi-stage image. Build it with:
 
 ```bash
-docker buildx build --platform linux/arm64 -t ghcr.io/your-org/rustspray:latest \
+docker buildx build --platform linux/arm64 -t ghcr.io/cropcrusaders/rustspray:latest \
   -f Dockerfile.cross-aarch64 .
 ```
 The resulting image contains `/usr/local/bin/rustspray` together with the

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -15,4 +15,8 @@ RUN dpkg --add-architecture arm64 \
         libunwind-dev:arm64 \
         pkg-config:arm64 \
         ninja-build:arm64 \
+        libavcodec-dev:arm64 \
+        libavformat-dev:arm64 \
+        libavutil-dev:arm64 \
+        libswscale-dev:arm64 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,18 +1,31 @@
-FROM ubuntu:22.04
+# ---------- build stage: fetch all the right armhf libs ----------
+FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
-# Enable the ARMHF architecture and clean up unused ones
-RUN dpkg --add-architecture armhf \
-    && dpkg --remove-architecture i386 || true \
-    && sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
-    && printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' \
-             'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main universe restricted\n' \
-             > /etc/apt/sources.list.d/armhf.list \
-    && apt-get -o Acquire::Retries=3 update \
-    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
-        libopencv-dev:armhf \
-        libunwind-dev:armhf \
+# Enable armhf architecture and Universe repo (where libav* lives)
+RUN dpkg --add-architecture armhf && \
+    sed -Ei 's/^# deb-src/deb-src/' /etc/apt/sources.list && \
+    add-apt-repository universe && \
+    apt-get update
+
+# Pull in OpenCV and FFmpeg *dev* packages for armhf
+RUN apt-get install -y --no-install-recommends \
+        gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         pkg-config:armhf \
-        ninja-build:armhf \
-    && rm -rf /var/lib/apt/lists/*
+        libopencv-dev:armhf \
+        libavcodec-dev:armhf \
+        libavformat-dev:armhf \
+        libavutil-dev:armhf \
+        libswscale-dev:armhf
+
+# ---------- final stage: image that cross will mount as sysroot ----------
+FROM --platform=linux/arm/v7 ubuntu:22.04
+
+# copy the entire armhf sysroot we just populated
+COPY --from=pkgstage /usr/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/
+COPY --from=pkgstage /usr/lib/arm-linux-gnueabihf/ /usr/lib/arm-linux-gnueabihf/
+COPY --from=pkgstage /usr/include/arm-linux-gnueabihf/ /usr/include/arm-linux-gnueabihf/
+
+# make pkg-config aware of the armhf .pc files
+ENV PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig
+
+# nothing else needed – this is a "sysroot only" image for cross-rs


### PR DESCRIPTION
## Summary
- install FFmpeg libs in the arm sysroot images
- build & push a new armv7 Docker image in CI
- wait for both Docker images before cross compiling
- update container registry name from `your-org` to `cropcrusaders`

## Testing
- `cargo check` *(fails: failed to download crates)*


------
https://chatgpt.com/codex/tasks/task_e_683bb070227c83219dfc108be5e46d81