### PR TITLE
Fix tzdata prompt

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -1,5 +1,18 @@
 FROM arm64v8/ubuntu:22.04
 
+# Configure tzdata non-interactively early in the build so any later package
+# installations do not block waiting for user input.  This is required when
+# building in CI environments such as GitHub Actions.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
## Summary
- set `DEBIAN_FRONTEND=noninteractive`
- preconfigure tzdata with `Australia/Brisbane` timezone

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bc032f5848321ab580b80889cfacc