### PR TITLE
Fix rustup install in aarch64 Dockerfile

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -19,6 +19,7 @@ RUN apt-get update \
         pkg-config \
         cmake \
         curl \
+        ca-certificates \
         ffmpeg \
         libopencv-dev \
         libavcodec-dev \


### PR DESCRIPTION
## Summary
- install `ca-certificates` in the `aarch64` Dockerfile so rustup can use HTTPS

## Testing
- `cargo test --all` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bc49b5d0c8321a17c691d4427d3d0