### PR TITLE
Fix armv7 Dockerfile build failure

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -3,6 +3,8 @@ FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
 # Enable armhf architecture and Universe repo (where libav* lives)
 RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
     sed -Ei 's/^# deb-src/deb-src/' /etc/apt/sources.list && \
     add-apt-repository universe && \
     apt-get update


### PR DESCRIPTION
## Summary
- install `software-properties-common` before calling `add-apt-repository`

## Testing
- `cargo check` *(fails: couldn't finish due to missing build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683bc64c2f248321b11d8cc9c3db7e3c