### PR TITLE
Fix armv7 package indexes

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -3,9 +3,14 @@ FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
 # Enable armhf architecture and Universe repo (where libav* lives)
 RUN dpkg --add-architecture armhf && \
+    sed -i -e 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' \
+        -e 's|http://security.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' \
+        /etc/apt/sources.list && \
+    apt-get -o Acquire::Retries=3 update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
     sed -Ei 's/^# deb-src/deb-src/' /etc/apt/sources.list && \
     add-apt-repository universe && \
-    apt-get update
+    apt-get -o Acquire::Retries=3 update
 
 # Pull in OpenCV and FFmpeg *dev* packages for armhf
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- update apt sources to use `ports.ubuntu.com` in the armv7 Dockerfile

## Testing
- `cargo check` *(fails: couldn't connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683bc64c2f248321b11d8cc9c3db7e3c