### PR TITLE
Improve GHCR workflow handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,17 @@ jobs:
   build:
     needs: [build-aarch64-image, build-armv7]
     runs-on: ubuntu-latest
+    env:
+      GHCR_USER: ${{ github.repository_owner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            image: ghcr.io/your-org/aarch64-opencv:latest
+            image: ghcr.io/${{ github.repository_owner }}/aarch64-opencv:latest
             arch: arm64
           - target: armv7-unknown-linux-gnueabihf
-            image: ghcr.io/your-org/armv7-opencv:latest
+            image: ghcr.io/${{ github.repository_owner }}/armv7-opencv:latest
             arch: armv7
             continue-on-error: true
 
@@ -87,7 +89,7 @@ jobs:
     env:
       IMAGE_TAG: "latest"
       DOCKERFILE_PATH: "docker/Dockerfile.aarch64"
-      GHCR_USER: "your-org"
+      GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -101,19 +103,28 @@ jobs:
           username: ${{ env.GHCR_USER }}
           password: ${{ env.GHCR_TOKEN }}
       - name: Build and push ARM64 builder image
+        if: env.GHCR_TOKEN != ''
         run: |
           docker buildx build \
             --platform linux/arm64 \
-            -t ghcr.io/your-org/aarch64-opencv:${{ env.IMAGE_TAG }} \
+            -t ghcr.io/${{ env.GHCR_USER }}/aarch64-opencv:${{ env.IMAGE_TAG }} \
             -f ${{ env.DOCKERFILE_PATH }} \
             --push .
+      - name: Build ARM64 image without push
+        if: env.GHCR_TOKEN == ''
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            -t ghcr.io/${{ env.GHCR_USER }}/aarch64-opencv:${{ env.IMAGE_TAG }} \
+            -f ${{ env.DOCKERFILE_PATH }} \
+            --load .
 
   build-armv7:
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: "latest"
       DOCKERFILE_PATH: "docker/Dockerfile.armv7"
-      GHCR_USER: "your-org"
+      GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -131,8 +142,8 @@ jobs:
       - name: Build ARMv7 builder image
         run: |
           docker build \
-            -t ghcr.io/your-org/armv7-opencv:${{ env.IMAGE_TAG }} \
+            -t ghcr.io/${{ env.GHCR_USER }}/armv7-opencv:${{ env.IMAGE_TAG }} \
             -f ${{ env.DOCKERFILE_PATH }} .
       - name: Push image
         if: env.GHCR_TOKEN != ''
-        run: docker push ghcr.io/your-org/armv7-opencv:${{ env.IMAGE_TAG }}
+        run: docker push ghcr.io/${{ env.GHCR_USER }}/armv7-opencv:${{ env.IMAGE_TAG }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,8 @@
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/your-org/aarch64-opencv:latest"
+image = "ghcr.io/${GHCR_USER}/aarch64-opencv:latest"
 xargo = false
 
 
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/your-org/armv7-opencv:latest"
+image = "ghcr.io/${GHCR_USER}/armv7-opencv:latest"

--- a/README.md
+++ b/README.md
@@ -99,16 +99,21 @@ If you prefer to build inside a container you can create the images used by
 
 ```bash
 # For 64-bit ARM targets
-docker build -f Dockerfile.pi-opencv -t ghcr.io/your-org/aarch64-opencv:latest .
+docker build -f Dockerfile.pi-opencv -t ghcr.io/<your-namespace>/aarch64-opencv:latest .
 
 # For 32-bit ARM targets
-docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/your-org/armv7-opencv:latest .
+docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/<your-namespace>/armv7-opencv:latest .
 ```
 
 These Dockerfiles install common build tools and now include
 `libunwind-dev` for the target architecture. This resolves missing
 dependencies when building ROS 2 packages such as `nav2` inside the
 container.
+
+When publishing these images to GitHub Container Registry (GHCR) you must
+provide a `GHCR_TOKEN` secret with `write:packages` permission. The
+workflows use `${{ github.repository_owner }}` as the namespace for the
+image tags, so the token needs permission to push to that account.
 
 Install [`cross`](https://github.com/cross-rs/cross) from the GitHub repository
 and build using the image. The crate is no longer published on crates.io, so the
@@ -126,7 +131,7 @@ image, for example:
 
 ```bash
 docker run --rm -it -v $(pwd):/project -w /project \
-  ghcr.io/your-org/aarch64-opencv:latest cargo test
+  ghcr.io/<your-namespace>/aarch64-opencv:latest cargo test
 ```
 
 An all-in-one Dockerfile named `Dockerfile.cross-aarch64` is provided for
@@ -134,7 +139,7 @@ convenience. It builds OpenCV from source and then cross-compiles the project
 for `aarch64-unknown-linux-gnu` in a single multi-stage image. Build it with:
 
 ```bash
-docker buildx build --platform linux/arm64 -t ghcr.io/your-org/rustspray:latest \
+docker buildx build --platform linux/arm64 -t ghcr.io/<your-namespace>/rustspray:latest \
   -f Dockerfile.cross-aarch64 .
 ```
 The resulting image contains `/usr/local/bin/rustspray` together with the


### PR DESCRIPTION
## Summary
- only push ARM64 builder image when credentials exist
- clarify GHCR usage in documentation

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bc74615988321b7e2e6eb8cd94cb1