### PR TITLE
Fix Yocto parse error

### DIFF
--- a/yocto/build/conf/local.conf
+++ b/yocto/build/conf/local.conf
@@ -2,7 +2,9 @@ MACHINE ??= "qemuarm64"
 DISTRO ?= "poky"
 PACKAGE_CLASSES ?= "package_rpm"
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
-USER_CLASSES ?= "buildstats image-prelink"
+# The image-prelink class was removed from newer Yocto releases.
+# Remove it from USER_CLASSES to avoid parse errors.
+USER_CLASSES ?= "buildstats"
 TMPDIR = "${TOPDIR}/tmp"
 
 BB_NUMBER_THREADS = "4"

--- a/yocto/meta-rust-spray/conf/layer.conf
+++ b/yocto/meta-rust-spray/conf/layer.conf
@@ -4,3 +4,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb"
 BBFILE_COLLECTIONS += "meta-rust-spray"
 BBFILE_PATTERN_meta-rust-spray = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rust-spray = "6"
+
+# Declare compatibility with recent Yocto releases. This silences
+# warnings during the build.
+LAYERSERIES_COMPAT_meta-rust-spray = "nanbield scarthgap"


### PR DESCRIPTION
## Summary
- remove `image-prelink` from `USER_CLASSES` to avoid missing class error
- declare Yocto layer compatibility

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_683bcaacabf48321a191c0cfc0d19074