### PR TITLE
Fix armv7 Docker build

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -3,9 +3,9 @@ FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
 # Enable armhf architecture and Universe repo (where libav* lives)
 RUN dpkg --add-architecture armhf && \
-    sed -i -e 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' \
-        -e 's|http://security.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' \
-        /etc/apt/sources.list && \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' > /etc/apt/sources.list.d/armhf.list && \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' >> /etc/apt/sources.list.d/armhf.list && \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' >> /etc/apt/sources.list.d/armhf.list && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     sed -Ei 's/^# deb-src/deb-src/' /etc/apt/sources.list && \


### PR DESCRIPTION
## Summary
- add armhf sources separately so `apt-get update` keeps amd64 repos

## Testing
- `cargo test --quiet` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683bcb46ef548321a995248130829de5