### PR TITLE
Fix layer compatibility for walnascar

### DIFF
--- a/yocto/meta-rust-spray/conf/layer.conf
+++ b/yocto/meta-rust-spray/conf/layer.conf
@@ -7,4 +7,4 @@ BBFILE_PRIORITY_meta-rust-spray = "6"
 
 # Declare compatibility with recent Yocto releases. This silences
 # warnings during the build.
-LAYERSERIES_COMPAT_meta-rust-spray = "nanbield scarthgap"
+LAYERSERIES_COMPAT_meta-rust-spray = "nanbield scarthgap walnascar"


### PR DESCRIPTION
## Summary
- extend Yocto layer compatibility to walnascar

## Testing
- `cargo test` *(fails: failed to download crates - could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683bce7e84f08321b3ae5894bca3e935