### PR TITLE
Fix armhf apt repos in Dockerfile

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -3,6 +3,7 @@ FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
 # Enable armhf architecture and Universe repo (where libav* lives)
 RUN dpkg --add-architecture armhf && \
+    sed -Ei 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \
     printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' > /etc/apt/sources.list.d/armhf.list && \
     printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' >> /etc/apt/sources.list.d/armhf.list && \
     printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' >> /etc/apt/sources.list.d/armhf.list && \


### PR DESCRIPTION
## Summary
- fix apt sources in `docker/Dockerfile.armv7` so `apt-get update` doesn't fetch armhf packages from archive.ubuntu.com

## Testing
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bd10016008321821fb21bcf512286