### PR TITLE
Fix Yocto layer recipe search path

### DIFF
--- a/yocto/meta-rust-spray/conf/layer.conf
+++ b/yocto/meta-rust-spray/conf/layer.conf
@@ -1,6 +1,8 @@
 # Minimal layer configuration for Rust-Spray Yocto layer
 BBPATH .= ":${LAYERDIR}"
-BBFILES += "${LAYERDIR}/recipes-*/*/*.bb"
+# Include both one-level and two-level recipe directories so that
+# image recipes placed directly under "recipes-<category>" are picked up.
+BBFILES += "${LAYERDIR}/recipes-*/*.bb ${LAYERDIR}/recipes-*/*/*.bb"
 BBFILE_COLLECTIONS += "meta-rust-spray"
 BBFILE_PATTERN_meta-rust-spray = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rust-spray = "6"


### PR DESCRIPTION
## Summary
- allow image recipes directly under `recipes-<category>`

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bd0d37d8083219ca0d00a45a84bd1