### PR TITLE
Fix Yocto recipe paths

### DIFF
--- a/yocto/meta-rust-spray/recipes-apps/rust-spray/rust-spray.bb
+++ b/yocto/meta-rust-spray/recipes-apps/rust-spray/rust-spray.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Rust-Spray weed detection application"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://../../../../LICENSE;md5=9d852dbaca7af3fd17c0249a3f04e40d"
 
-SRC_URI = "git://github.com/cropcrusaders/Rust-Spray.git;branch=main"
+SRC_URI = "git://github.com/cropcrusaders/Rust-Spray.git;branch=main;protocol=https"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/yocto/meta-rust-spray/recipes-images/rust-spray-image.bb
+++ b/yocto/meta-rust-spray/recipes-images/rust-spray-image.bb
@@ -5,4 +5,4 @@ inherit core-image
 IMAGE_INSTALL += "rust-spray"
 
 # Use the sato GUI for a lightweight interface
-require recipes-core/images/core-image-sato.bb
+require recipes-sato/images/core-image-sato.bb


### PR DESCRIPTION
## Summary
- fix path to core-image-sato.bb in custom image recipe
- update rust-spray recipe to use https when fetching from GitHub

## Testing
- `cargo test` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683bd5f5ef9483219220b396336d797e