### PR TITLE
Set timezone for armv7 Docker builds

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -1,5 +1,16 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
 
+# Configure tzdata non-interactively to avoid prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install required dependencies for OpenCV
 RUN rm -rf /etc/apt/sources.list.d/* && \
     printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
@@ -42,6 +53,15 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
 RUN rm -rf /etc/apt/sources.list.d/* && \
     printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
            'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -1,5 +1,16 @@
 FROM ubuntu:22.04 AS builder
 
+# Configure tzdata non-interactively to avoid prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install required dependencies for OpenCV
 RUN dpkg --add-architecture armhf && \
     dpkg --remove-architecture i386 || true && \
@@ -39,6 +50,15 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
 
 # Final image: will be used by cross
 FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
 RUN dpkg --add-architecture armhf && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,6 +1,17 @@
 # ---------- build stage: fetch all the right armhf libs ----------
 FROM --platform=linux/amd64 ubuntu:22.04 AS pkgstage
 
+# Configure tzdata non-interactively to avoid prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
 # Enable armhf architecture and Universe repo (where libav* lives)
 RUN dpkg --add-architecture armhf && \
     sed -Ei 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \


### PR DESCRIPTION
## Summary
- avoid tzdata prompts during armv7 Docker builds by preconfiguring tzdata
- set `DEBIAN_FRONTEND=noninteractive` and `TZ=Australia/Brisbane`

## Testing
- `cargo test --quiet` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bd67f9c7c8321a85446ee071adfc3