### PR TITLE
Add GHCR login instructions and workflow login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GHCR_USER: ${{ github.repository_owner }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +46,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: env.GHCR_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ env.GHCR_TOKEN }}
 
       - name: Install cargo-deb
         if: github.event_name == 'release'

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ provide a `GHCR_TOKEN` secret with `write:packages` permission. The
 workflows use `${{ github.repository_owner }}` as the namespace for the
 image tags, so the token needs permission to push to that account.
 
+To **pull** these images from GHCR you must also authenticate. Use a
+Personal Access Token (PAT) with at least `read:packages` permission and
+log in before running `docker pull`:
+
+```bash
+echo <your_token> | docker login ghcr.io -u <your_username> --password-stdin
+```
+
 Install [`cross`](https://github.com/cross-rs/cross) from the GitHub repository
 and build using the image. The crate is no longer published on crates.io, so the
 `--git` option must be used. You may lock to a tag such as `v0.2.6` or


### PR DESCRIPTION
## Summary
- document how to authenticate when pulling GHCR images
- login to GHCR in the build workflow before pulling images

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683bd98f2e848321a6df05df51647104