### PR TITLE
Fix Yocto build instructions

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -20,6 +20,12 @@ jobs:
             git clone --depth 1 https://git.yoctoproject.org/git/poky yocto/poky
           fi
 
+      - name: Ensure meta-openembedded layer
+        run: |
+          if [ ! -e yocto/meta-openembedded/meta-oe ]; then
+            git clone --depth 1 https://github.com/openembedded/meta-openembedded.git yocto/meta-openembedded
+          fi
+
       - name: Set up Poky build environment
         run: |
           source yocto/poky/oe-init-build-env yocto/build

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ machine with the Yocto build dependencies installed:
 ```bash
 cd yocto
 git clone --depth 1 https://git.yoctoproject.org/git/poky poky
+git clone --depth 1 https://github.com/openembedded/meta-openembedded.git meta-openembedded
 source poky/oe-init-build-env build
 bitbake rust-spray-image
 ```

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -9,6 +9,7 @@ Steps to build locally:
 ```bash
 cd yocto
 git clone --depth 1 https://git.yoctoproject.org/git/poky poky   # fetch Poky if not using submodules
+git clone --depth 1 https://github.com/openembedded/meta-openembedded.git meta-openembedded
 source poky/oe-init-build-env build
 # Edit `conf/local.conf` and replace the deprecated
 # `EXTRA_IMAGE_FEATURES ?= "debug-tweaks"` line with:

--- a/yocto/build/conf/bblayers.conf
+++ b/yocto/build/conf/bblayers.conf
@@ -4,8 +4,9 @@ BBFILES ?= ""
 POKY_BBLAYERS := " \ 
   ${TOPDIR}/../poky/meta \ 
   ${TOPDIR}/../poky/meta-poky \ 
-  ${TOPDIR}/../poky/meta-yocto-bsp \ 
-  ${TOPDIR}/../meta-rust-spray \ 
+  ${TOPDIR}/../poky/meta-yocto-bsp \
+  ${TOPDIR}/../meta-rust-spray \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
   "
 
 BBLAYERS ?= "${POKY_BBLAYERS}"


### PR DESCRIPTION
## Summary
- add meta-openembedded layer to BBLAYERS
- fetch meta-openembedded in the Yocto workflow
- document cloning meta-openembedded in both READMEs

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683bda5477d8832180a955deac9baf32