### PR TITLE
Fix GHCR login step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: ["main"]
@@ -48,12 +52,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: env.GHCR_TOKEN != ''
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ env.GHCR_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-deb
         if: github.event_name == 'release'
@@ -105,12 +108,11 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
-        if: env.GHCR_TOKEN != ''
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ env.GHCR_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Build and push ARM64 builder image
         if: env.GHCR_TOKEN != ''
         run: |
@@ -142,12 +144,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
-        if: env.GHCR_TOKEN != ''
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ env.GHCR_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Build ARMv7 builder image
         run: |
           docker build \


### PR DESCRIPTION
## Summary
- let the build workflow log in to GHCR using the default GITHUB_TOKEN
- grant `packages: read` permission to the workflow

## Testing
- `cargo test --quiet` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683be469fa70832196782afeedcb9523