### PR TITLE
Disable OpenSSL tests in Yocto layer

### DIFF
--- a/yocto/meta-rust-spray/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/yocto/meta-rust-spray/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,2 @@
+# Disable building of OpenSSL tests and fuzzers to avoid link errors during cross compile
+EXTRA_OECONF:append = " no-tests no-fuzz"


### PR DESCRIPTION
## Summary
- disable building fuzz/tests in OpenSSL recipe via bbappend

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683be676a330832189bd48b627d9b51e