### PR TITLE
Fix cross image variable substitution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Substitute GHCR_USER in Cross.toml
+        run: |
+          envsubst < Cross.toml > Cross.expanded.toml
+          mv Cross.expanded.toml Cross.toml
+        env:
+          GHCR_USER: ${{ github.repository_owner }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Substitute GHCR_USER in Cross.toml
+        run: |
+          envsubst < Cross.toml > Cross.expanded.toml
+          mv Cross.expanded.toml Cross.toml
+        env:
+          GHCR_USER: ${{ github.repository_owner }}
+
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- expand `GHCR_USER` variable in `Cross.toml` before building
- apply the same fix in release workflow

## Testing
- `cargo test --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683bf37681248321b114cdb974a179a5