### PR TITLE
Add pixman clean step in Yocto workflow

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Set up Poky build environment
         run: |
           source yocto/poky/oe-init-build-env yocto/build
+          # Work around occasional Meson clock skew errors
+          # by cleaning the pixman recipe before building
+          bitbake -c clean pixman || true
           bitbake rust-spray-image
 
       - name: Upload image artifact

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -14,6 +14,9 @@ source poky/oe-init-build-env build
 # Edit `conf/local.conf` and replace the deprecated
 # `EXTRA_IMAGE_FEATURES ?= "debug-tweaks"` line with:
 # `EXTRA_IMAGE_FEATURES ?= "allow-root-login allow-empty-password"`
+# If the build fails with a Meson "clock skew" error, clean
+# the pixman recipe first:
+bitbake -c clean pixman
 bitbake rust-spray-image
 ```
 


### PR DESCRIPTION
## Summary
- work around Meson clock skew errors in the Yocto CI job by cleaning `pixman`
- document this in the Yocto README

## Testing
- `cargo test` *(fails: Could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683bf85788648321813d8e5ed1a36d67