### PR TITLE
Fix apt sources for arm64 Docker build

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:22.04
 
-# Enable the ARM64 architecture and clean up unused ones
+# Enable the ARM64 architecture. The default Ubuntu sources only host
+# amd64 packages, so switch to the ports repository which provides
+# binaries for additional architectures before attempting to install
+# ARM64 packages.
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
+    && sed -i 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \


### PR DESCRIPTION
## Summary
- update `aarch64-opencv.dockerfile` to use `ports.ubuntu.com` when pulling arm64 packages

## Testing
- `cargo test --all --no-run` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683c1271fce08321856a4760f694de86