### PR TITLE
Fix apt sources for arm64 build

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -6,6 +6,9 @@ FROM ubuntu:22.04
 # 404 errors when the amd64 repositories are queried.
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
+    # Use the Ubuntu ports mirror for the arm64 repository to avoid 404 errors
+    && sed -i 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* \
+    && sed -i 's|http://security.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \


### PR DESCRIPTION
## Summary
- ensure arm64 packages use the Ubuntu ports mirror in aarch64-opencv.dockerfile

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683d29f6e8748321a19b2232d396eef9