### PR TITLE
Fix Yocto build failures

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -32,6 +32,8 @@ jobs:
           # Work around occasional Meson clock skew errors
           # by cleaning the pixman recipe before building
           bitbake -c clean pixman || true
+          # Also clean glib to avoid intermittent Meson failures
+          bitbake -c clean glib-2.0-native || true
           bitbake rust-spray-image
 
       - name: Upload image artifact

--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ cd yocto
 git clone --depth 1 https://git.yoctoproject.org/git/poky poky
 git clone --depth 1 https://github.com/openembedded/meta-openembedded.git meta-openembedded
 source poky/oe-init-build-env build
+# If the build fails with a Meson "clock skew" error, clean pixman first
+bitbake -c clean pixman
+# If glib fails during configuration, clean its native recipe
+bitbake -c clean glib-2.0-native
 bitbake rust-spray-image
 ```
 

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -17,6 +17,8 @@ source poky/oe-init-build-env build
 # If the build fails with a Meson "clock skew" error, clean
 # the pixman recipe first:
 bitbake -c clean pixman
+# If glib fails during configuration, clean its native recipe:
+bitbake -c clean glib-2.0-native
 bitbake rust-spray-image
 ```
 


### PR DESCRIPTION
## Summary
- clean glib-2.0-native in Yocto workflow
- document cleaning glib when Yocto build fails

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683d2ac48dc88321acfef5126431a6fe