### PR TITLE
Fix sed wildcard in Dockerfile

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -7,8 +7,8 @@ FROM ubuntu:22.04
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
     # Use the Ubuntu ports mirror for the arm64 repository to avoid 404 errors
-    && sed -i 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* \
-    && sed -i 's|http://security.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* \
+    && sed -i 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true \
+    && sed -i 's|http://security.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \


### PR DESCRIPTION
## Summary
- handle missing `/etc/apt/sources.list.d` in aarch64-opencv Dockerfile

## Testing
- `cargo test` *(fails: couldn't access crates.io index)*

------
https://chatgpt.com/codex/tasks/task_e_683d2b9f026c83219e6a048eb6fb1aef