### PR TITLE
Fix apt sources for cross compile image

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -6,9 +6,6 @@ FROM ubuntu:22.04
 # 404 errors when the amd64 repositories are queried.
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
-    # Use the Ubuntu ports mirror for the arm64 repository to avoid 404 errors
-    && sed -i 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true \
-    && sed -i 's|http://security.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \


### PR DESCRIPTION
## Summary
- fix apt sources in aarch64-opencv Dockerfile to avoid 404 errors during build

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683d2c8d5fa883218e23b2d1394dcf7b