### PR TITLE
Fix apt sources for arm64 cross build

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,11 +1,14 @@
 FROM ubuntu:22.04
 
 # Enable the ARM64 architecture for cross-compiling OpenCV. The default
-# Ubuntu mirrors already provide arm64 packages, so we simply add the
-# architecture and keep the existing sources list intact. This avoids
-# 404 errors when the amd64 repositories are queried.
+# sources in the Ubuntu image only contain packages for the host
+# architecture.  When we add a foreign architecture apt will attempt to
+# fetch `binary-arm64` indexes from the `archive.ubuntu.com` mirror which
+# does not host them, resulting in 404 errors.  Use the ports mirror for
+# arm64 packages instead.
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
+    && sed -Ei 's@http://archive.ubuntu.com/ubuntu@http://ports.ubuntu.com/ubuntu-ports@g' /etc/apt/sources.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \


### PR DESCRIPTION
## Summary
- update `aarch64-opencv.dockerfile` so apt can resolve arm64 packages

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683d2df978708321b57696539db60899