### PR TITLE
Fix apt mirror for security updates

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04
 # arm64 packages instead.
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
-    && sed -Ei 's@http://archive.ubuntu.com/ubuntu@http://ports.ubuntu.com/ubuntu-ports@g' /etc/apt/sources.list \
+    && sed -Ei 's@http://archive.ubuntu.com/ubuntu@http://ports.ubuntu.com/ubuntu-ports@g;s@http://security.ubuntu.com/ubuntu@http://ports.ubuntu.com/ubuntu-ports@g' /etc/apt/sources.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libopencv-dev:arm64 \


### PR DESCRIPTION
## Summary
- fix apt mirror in `aarch64-opencv.dockerfile` to avoid 404 errors when adding arm64 architecture

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `env_logger` found)*

------
https://chatgpt.com/codex/tasks/task_e_683d5b8432d48321a70489ebfca7e460