### PR TITLE
Fix Meson clock skew by cleaning glib-initial

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -34,6 +34,9 @@ jobs:
           bitbake -c clean pixman || true
           # Also clean glib to avoid intermittent Meson failures
           bitbake -c clean glib-2.0-native || true
+          # And clean the glib-initial recipe which sometimes hits
+          # the same Meson clock skew issue
+          bitbake -c clean glib-2.0-initial || true
           bitbake rust-spray-image
 
       - name: Upload image artifact

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ source poky/oe-init-build-env build
 bitbake -c clean pixman
 # If glib fails during configuration, clean its native recipe
 bitbake -c clean glib-2.0-native
+# If the initial glib build also fails, clean its recipe
+bitbake -c clean glib-2.0-initial
 bitbake rust-spray-image
 ```
 

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -19,6 +19,8 @@ source poky/oe-init-build-env build
 bitbake -c clean pixman
 # If glib fails during configuration, clean its native recipe:
 bitbake -c clean glib-2.0-native
+# If it still fails during the initial build, clean that recipe as well:
+bitbake -c clean glib-2.0-initial
 bitbake rust-spray-image
 ```
 


### PR DESCRIPTION
## Summary
- clean the glib-2.0-initial recipe in the Yocto workflow
- update build instructions in README and yocto/README with the new clean step

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683d5bd249a4832193fd402afd92df0c