### PR TITLE
Set timezone in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      TZ: Australia/Brisbane
     strategy:
       fail-fast: false
       matrix:
@@ -125,6 +126,7 @@ jobs:
       DOCKERFILE_PATH: "docker/aarch64-opencv.dockerfile"
       GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      TZ: Australia/Brisbane
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -168,6 +170,7 @@ jobs:
       DOCKERFILE_PATH: "docker/Dockerfile.armv7"
       GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      TZ: Australia/Brisbane
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU (needed for multi-arch builds)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,7 @@ jobs:
       if: env.no_changes == 'false'
       env:
         GH_TOKEN: ${{ secrets.PAT_PUSH}}     # authenticate gh CLI
+        TZ: Australia/Brisbane
       run: |
         # unique branch name
         BRANCH="lockfix/refresh-$(date +%Y-%m-%d-%H%M)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           mv Cross.expanded.toml Cross.toml
         env:
           GHCR_USER: ${{ github.repository_owner }}
+          TZ: Australia/Brisbane
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- set `TZ` environment variable in all GitHub workflows

## Testing
- `cargo test --locked --offline` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683d5f39abf083219d5929e2c00642d2