### PR TITLE
Fix cross build images for ARM64 and ARMv7

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -37,6 +37,23 @@ RUN apt-get install -y --no-install-recommends \
 # ---------- final stage: image that cross will mount as sysroot ----------
 FROM --platform=linux/arm/v7 ubuntu:22.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Australia/Brisbane
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
 # copy the entire armhf sysroot we just populated
 COPY --from=pkgstage /usr/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/
 COPY --from=pkgstage /usr/lib/arm-linux-gnueabihf/ /usr/lib/arm-linux-gnueabihf/

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -27,6 +27,8 @@ RUN dpkg --add-architecture arm64 \
     && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse\n' >> /etc/apt/sources.list.d/arm64.list \
     && apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        build-essential \
+        gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libopencv-dev:arm64 \
         pkg-config:arm64 \
         ninja-build:arm64 \


### PR DESCRIPTION
## Summary
- install `build-essential` and target compilers inside the ARM64 and ARMv7 Docker images

## Testing
- `cargo check` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e13ec0ee08321a617c4b1f841b29b