### PR TITLE
Fix aarch64 Dockerfile apt step

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -31,6 +31,6 @@ RUN dpkg --add-architecture arm64 \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libopencv-dev:arm64 \
         pkg-config:arm64 \
-        ninja-build:arm64 \
-    && rm -rf /var/lib/apt/lists/*
+        ninja-build \
+        && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- use host architecture ninja-build for aarch64 cross image

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683e1706e0108321be2f78c269df80cf