### PR TITLE
Fix cross container pkg-config

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -30,7 +30,7 @@ RUN dpkg --add-architecture arm64 \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libopencv-dev:arm64 \
-        pkg-config:arm64 \
+        pkg-config \
         ninja-build \
         && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- use host `pkg-config` instead of target binary in `aarch64-opencv` container to make cross-compilation work

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e19ee46988321a1d28b9f96fee16c