### PR TITLE
Fix cross build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           cargo install --git https://github.com/cross-rs/cross cross --locked
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Build for aarch64
         run: cross build --release --target aarch64-unknown-linux-gnu
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Guidelines for Codex Agents
+
+This repository uses Rust and Docker-based cross compilation to target
+embedded Linux boards like the Raspberry Pi.
+
+## Code Style
+- Run `cargo fmt` before committing.
+- Document public functions using Rustdoc comments.
+- Keep functions small and focused.
+
+## Testing
+- Execute `cargo test` for the host architecture before opening a pull request.
+
+## Cross Compilation
+To produce Raspberry Pi binaries the project relies on the
+[cross](https://github.com/cross-rs/cross) tool and Docker images
+specified in `Cross.toml`.
+
+### Installing the `cross` CLI
+The crate is no longer published on crates.io. Install it directly from
+GitHub:
+
+```bash
+cargo install --git https://github.com/cross-rs/cross cross --locked
+```
+
+Docker must be available to the current user. The images referenced in
+`Cross.toml` should be downloaded ahead of time if working offline.
+
+### Building for `armv7-unknown-linux-gnueabihf`
+Run the following command:
+
+```bash
+cross build --release --target armv7-unknown-linux-gnueabihf --verbose
+```
+
+The resulting binary will be located in
+`target/armv7-unknown-linux-gnueabihf/release/`.


### PR DESCRIPTION
## Summary
- enable QEMU emulation in build and release workflows so cross can run ARM containers

## Testing
- `cargo fmt` *(failed: rustfmt not installed)*
- `cargo test` *(failed: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683e19c9932c8321bd6a6a19681bae4f