### PR TITLE
Fix cross libc dependencies for aarch64 image

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -29,6 +29,7 @@ RUN dpkg --add-architecture arm64 \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+        libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
         libopencv-dev:arm64 \
         pkg-config \
         ninja-build \


### PR DESCRIPTION
## Summary
- ensure `linux-libc-dev-arm64-cross` and `libc6-dev-arm64-cross` are installed in `aarch64-opencv` Dockerfile

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683e1c4bc97483219a45c4f65eaefa49