### PR TITLE
Fix cross compile image for armv7

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -35,7 +35,7 @@ RUN apt-get install -y --no-install-recommends \
         libswscale-dev:armhf
 
 # ---------- final stage: image that cross will mount as sysroot ----------
-FROM --platform=linux/arm/v7 ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Australia/Brisbane


### PR DESCRIPTION
## Summary
- fix the armv7 Dockerfile so `cross` can run it on x86 hosts

## Testing
- `cargo test --locked` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683e1ecb50ac83219b41b8814ce6b163