### PR TITLE
Fix armv7 cross image architecture

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -35,7 +35,11 @@ RUN apt-get install -y --no-install-recommends \
         libswscale-dev:armhf
 
 # ---------- final stage: image that cross will mount as sysroot ----------
-FROM --platform=linux/arm/v7 ubuntu:22.04
+# The final image must match the host architecture so that the x86_64
+# Rust toolchain provided by `cross` can run inside it. Building an
+# ARMv7 image would prevent cargo from executing. Use an amd64 base
+# while still providing the ARMv7 sysroot.
+FROM --platform=linux/amd64 ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Australia/Brisbane


### PR DESCRIPTION
## Summary
- build the armv7 cross image for amd64 instead of armv7

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo test` *(fails: couldn't download crates)*


------
https://chatgpt.com/codex/tasks/task_e_683e2201369c832182f3586c5e280062