### PR TITLE
Fix armv7 build image

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -60,6 +60,8 @@ COPY --from=pkgstage /usr/lib/arm-linux-gnueabihf/ /usr/lib/arm-linux-gnueabihf/
 COPY --from=pkgstage /usr/include/arm-linux-gnueabihf/ /usr/include/arm-linux-gnueabihf/
 
 # make pkg-config aware of the armhf .pc files
-ENV PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig \
+    PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig \
+    PKG_CONFIG_SYSROOT_DIR=/
 
 # nothing else needed – this is a “sysroot only” image for cross-rs


### PR DESCRIPTION
## Summary
- update armv7 cross container to export pkg-config variables

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo test --locked` *(fails: could not download index)*

------
https://chatgpt.com/codex/tasks/task_e_683e239d98648321a8138703d20c494b