### PR TITLE
Improve cross-compilation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,15 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build for aarch64
+        env:
+          PKG_CONFIG_ALLOW_CROSS: "1"
+          CARGO_INCREMENTAL: "0"
         run: cross build --release --target aarch64-unknown-linux-gnu
 
       - name: Build for armv7
+        env:
+          PKG_CONFIG_ALLOW_CROSS: "1"
+          CARGO_INCREMENTAL: "0"
         run: cross build --release --target armv7-unknown-linux-gnueabihf
 
       - name: Prepare artefacts

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -38,18 +38,20 @@ cd Rust-Spray
 cargo build --release
 ```
 
-For Raspberry Pi cross‑compilation choose the appropriate target.
-For 64-bit OS:
+For Raspberry Pi cross‑compilation choose the appropriate target. The
+recommended approach is to use the `cross` tool together with the Docker
+images provided in this repository. This ensures that the OpenCV
+development libraries for the target architecture are available.
+
+Install `cross` from the GitHub repository and build with:
 
 ```bash
-cargo build --release --target aarch64-unknown-linux-gnu
+cargo install --git https://github.com/cross-rs/cross cross --locked
+cross build --release --target aarch64-unknown-linux-gnu
 ```
-For 32-bit OS:
-
-```bash
-cargo build --release --target armv7-unknown-linux-gnueabihf
-```
-Add `--features picam` when the Raspberry Pi camera module is required.
+Replace the target as needed (e.g. `armv7-unknown-linux-gnueabihf` for
+32‑bit). Add `--features picam` when the Raspberry Pi camera module is
+required.
 
 After compilation copy the binary from
 `target/aarch64-unknown-linux-gnu/release/` to your device.


### PR DESCRIPTION
## Summary
- update the wiki installation guide to use `cross` for Raspberry Pi
- add required env vars to release workflow for cross builds

## Testing
- `rustup component add rustfmt` *(fails: network unreachable)*
- `cargo fmt --all` *(fails: component missing)*
- `cargo test --locked --offline` *(fails: could not find `env_logger` crate)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683e26325db883219887120afac76ad2