### PR TITLE
Fix aarch64 build dependencies

### DIFF
--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -16,7 +16,7 @@ RUN dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
-        pkg-config pkg-config-aarch64-linux-gnu \
+        pkg-config \
         libgtk-3-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
@@ -62,7 +62,7 @@ RUN apt-get update && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config pkg-config-aarch64-linux-gnu && \
+    apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -31,7 +31,7 @@ RUN dpkg --add-architecture arm64 \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
         libopencv-dev:arm64 \
-        pkg-config pkg-config-aarch64-linux-gnu \
+        pkg-config \
         ninja-build \
         && rm -rf /var/lib/apt/lists/*
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- remove the non-existent `pkg-config-aarch64-linux-gnu` package

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo test` *(fails to fetch crates.io index)*

------
https://chatgpt.com/codex/tasks/task_e_683e2dcfdd6483219ff22398cc50c04d