### PR TITLE
Update aarch64 Docker image to use cross base

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -1,4 +1,8 @@
-FROM ubuntu:22.04
+# Start from the official cross image so the required
+# cross-compilation tooling and pkg-config wrappers are
+# already available. This avoids "pkg-config has not been
+# configured" errors when building OpenCV crates.
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 
 # Configure tzdata non-interactively so image builds do not block waiting
 # for timezone selection when a package pulls it in as a dependency.


### PR DESCRIPTION
## Summary
- fix the ARM64 Dockerfile by using cross-rs base image

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e31632ac88321adcc6f5c42ed0249