### PR TITLE
Fix apt sources sed duplication in cross Dockerfiles

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -14,7 +14,7 @@ RUN apt-get update && \
 
 # Enable armhf architecture and Universe repo (where libav* lives)
 RUN dpkg --add-architecture armhf && \
-    sed -Ei 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \
+    sed -Ei '/^deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \
     printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main universe restricted\n' > /etc/apt/sources.list.d/armhf.list && \
     printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main universe restricted\n' >> /etc/apt/sources.list.d/armhf.list && \
     printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main universe restricted\n' >> /etc/apt/sources.list.d/armhf.list && \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # arm64 packages instead.
 RUN dpkg --add-architecture arm64 \
     && dpkg --remove-architecture i386 || true \
-    && sed -Ei 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
+    && sed -Ei '/^deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
     && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse\n' > /etc/apt/sources.list.d/arm64.list \
     && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse\n' >> /etc/apt/sources.list.d/arm64.list \
     && printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse\n' >> /etc/apt/sources.list.d/arm64.list \


### PR DESCRIPTION
## Summary
- avoid duplicating architecture tags in Debian sources entries

## Testing
- `cargo fmt` *(fails: component missing)*
- `cargo test` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683e35cd4f6883218ba8e03a7f240bb1