### PR TITLE
Fix armv7 OpenCV header path

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -58,6 +58,7 @@ RUN apt-get update && \
 COPY --from=pkgstage /usr/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/
 COPY --from=pkgstage /usr/lib/arm-linux-gnueabihf/ /usr/lib/arm-linux-gnueabihf/
 COPY --from=pkgstage /usr/include/arm-linux-gnueabihf/ /usr/include/arm-linux-gnueabihf/
+COPY --from=pkgstage /usr/include/opencv4/ /usr/include/opencv4/
 
 # make pkg-config aware of the armhf .pc files
 ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig \


### PR DESCRIPTION
## Summary
- copy `/usr/include/opencv4` into the armv7 cross image so the build script finds OpenCV headers

## Testing
- `cargo fmt` *(fails: rustfmt missing)*
- `cargo test` *(fails: couldn't access crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683e338dc6a8832191a8e58d5ea3340a