### PR TITLE
Optimize OpenCV build

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -40,6 +40,7 @@ RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_opencv_legacy=OFF \
+        -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         ../opencv && \
     make -j$(nproc) && make install
 

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -37,6 +37,7 @@ RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_opencv_legacy=OFF \
+        -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         ../opencv && \
     make -j$(nproc) && make install
 

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -37,6 +37,7 @@ RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_opencv_legacy=OFF \
+        -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         ../opencv && \
     make -j$(nproc) && make install
 

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -28,7 +28,12 @@ RUN dpkg --add-architecture armhf && \
 RUN apt-get install -y --no-install-recommends \
         gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         pkg-config:armhf \
-        libopencv-dev:armhf \
+        libopencv-core-dev:armhf \
+        libopencv-imgproc-dev:armhf \
+        libopencv-highgui-dev:armhf \
+        libopencv-imgcodecs-dev:armhf \
+        libopencv-videoio-dev:armhf \
+        libopencv-objdetect-dev:armhf \
         libavcodec-dev:armhf \
         libavformat-dev:armhf \
         libavutil-dev:armhf \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -34,7 +34,12 @@ RUN dpkg --add-architecture arm64 \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
-        libopencv-dev:arm64 \
+        libopencv-core-dev:arm64 \
+        libopencv-imgproc-dev:arm64 \
+        libopencv-highgui-dev:arm64 \
+        libopencv-imgcodecs-dev:arm64 \
+        libopencv-videoio-dev:arm64 \
+        libopencv-objdetect-dev:arm64 \
         pkg-config \
         ninja-build \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- trim installed OpenCV packages in Docker images
- limit OpenCV modules built from source for smaller images

## Testing
- `cargo fmt` *(failed: component missing)*
- `cargo test` *(failed: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e4c845ec8832199228f31cd19f0b2