### PR TITLE
Fix Docker build apt sources

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -20,14 +20,6 @@ RUN apt-get update && \
 RUN rm -rf /etc/apt/sources.list.d/* && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
-    printf 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse\n' > /etc/apt/sources.list && \
-    printf 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-updates main restricted universe multiverse\n' >> /etc/apt/sources.list && \
-    printf 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-security main restricted universe multiverse\n' >> /etc/apt/sources.list && \
-    printf 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse\n' >> /etc/apt/sources.list && \
-    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted universe multiverse\n' > /etc/apt/sources.list.d/arm64.list && \
-    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted universe multiverse\n' >> /etc/apt/sources.list.d/arm64.list && \
-    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main restricted universe multiverse\n' >> /etc/apt/sources.list.d/arm64.list && \
-    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse\n' >> /etc/apt/sources.list.d/arm64.list && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
## Summary
- fix `aarch64-opencv.dockerfile` apt sources so build works

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e4d50e6388321a9bb7cf643fe36e6