### PR TITLE
Fix OpenCV pkg-config for arm images

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -28,6 +28,7 @@ RUN dpkg --add-architecture armhf && \
 RUN apt-get install -y --no-install-recommends \
         gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         pkg-config:armhf \
+        libopencv-dev:armhf \
         libopencv-core-dev:armhf \
         libopencv-imgproc-dev:armhf \
         libopencv-highgui-dev:armhf \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -25,6 +25,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
+        libopencv-dev:arm64 \
         libopencv-core-dev:arm64 \
         libopencv-imgproc-dev:arm64 \
         libopencv-highgui-dev:arm64 \


### PR DESCRIPTION
## Summary
- ensure OpenCV pkg-config files are installed in cross images

## Testing
- `cargo fmt` *(fails: component rustfmt not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e5272f3b88321945d4a37aba310f8