### PR TITLE
Fix AArch64 OpenCV build sources

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -28,6 +28,7 @@ RUN dpkg --add-architecture armhf && \
 RUN apt-get install -y --no-install-recommends \
         gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         pkg-config:armhf \
+        libopencv-dev:armhf \
         libopencv-core-dev:armhf \
         libopencv-imgproc-dev:armhf \
         libopencv-highgui-dev:armhf \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -18,6 +18,11 @@ RUN apt-get update && \
 
 # Reset package sources to avoid duplicate entries from the base image
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
@@ -25,6 +30,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
+        libopencv-dev:arm64 \
         libopencv-core-dev:arm64 \
         libopencv-imgproc-dev:arm64 \
         libopencv-highgui-dev:arm64 \


### PR DESCRIPTION
## Summary
- update `docker/aarch64-opencv.dockerfile` to point APT to `ports.ubuntu.com` so `libopencv` cross packages can be installed

## Testing
- `cargo fmt --all` *(fails: rustfmt component not installed)*
- `cargo test` *(fails to fetch crates; network unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_683e5272f3b88321945d4a37aba310f8