### PR TITLE
Fix aarch64 OpenCV image build

### DIFF
--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -28,6 +28,7 @@ RUN dpkg --add-architecture armhf && \
 RUN apt-get install -y --no-install-recommends \
         gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         pkg-config:armhf \
+        libopencv-dev:armhf \
         libopencv-core-dev:armhf \
         libopencv-imgproc-dev:armhf \
         libopencv-highgui-dev:armhf \

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -18,21 +18,39 @@ RUN apt-get update && \
 
 # Reset package sources to avoid duplicate entries from the base image
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    printf 'deb http://ports.ubuntu.com/ubuntu-ports focal main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-updates main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-security main universe\n' \
+           'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main universe\n' \
+           > /etc/apt/sources.list && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-        libc6-dev-arm64-cross linux-libc-dev-arm64-cross \
-        libopencv-core-dev:arm64 \
-        libopencv-imgproc-dev:arm64 \
-        libopencv-highgui-dev:arm64 \
-        libopencv-imgcodecs-dev:arm64 \
-        libopencv-videoio-dev:arm64 \
-        libopencv-objdetect-dev:arm64 \
-        pkg-config \
-        ninja-build && \
+        cmake ninja-build git pkg-config \
+        libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
+        libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+        libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
+        libatlas-base-dev libdc1394-22-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+# Build OpenCV for the aarch64 sysroot
+WORKDIR /opt
+RUN git clone --depth 1 -b 4.8.1 https://github.com/opencv/opencv.git && \
+    mkdir build && cd build && \
+    cmake -G Ninja ../opencv \
+        -DCMAKE_TOOLCHAIN_FILE=/usr/share/cmake-*/Modules/Platform/Linux-aarch64.cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release && \
+    ninja -j$(nproc) && ninja install && \
+    rm -rf /opt/opencv
+
+# Copy OpenCV to the location expected by cross
+RUN mkdir -p /usr/aarch64-linux-gnu && \
+    cp -r /usr/local/* /usr/aarch64-linux-gnu/
+
+ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig


### PR DESCRIPTION
## Summary
- cross-compile OpenCV from source in `aarch64-opencv.dockerfile`

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test` *(fails to download crates)*


------
https://chatgpt.com/codex/tasks/task_e_683e5272f3b88321945d4a37aba310f8