### PR TITLE
Update OpenCV build configuration

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -25,8 +25,8 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
 
 # Build and install OpenCV for ARMv7
 WORKDIR /opt
-RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv_contrib.git && \
+RUN git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv_contrib.git && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -35,6 +35,7 @@ RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_opencv_legacy=OFF \
+        -DWITH_IPP=OFF \
         -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         ../opencv && \
     make -j$(nproc) && make install

--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -4,7 +4,7 @@
 # ------------------------------------------------------------
 # Stage 1 - Build OpenCV for aarch64
 # ------------------------------------------------------------
-ARG OPENCV_VERSION=4.8.1
+ARG OPENCV_VERSION=4.11.0
 ARG CMAKE_BUILD_TYPE=Release
 FROM ubuntu:22.04 AS opencv-build
 
@@ -39,6 +39,7 @@ RUN git clone --depth 1 -b ${OPENCV_VERSION} https://github.com/opencv/opencv.gi
         -DCMAKE_INSTALL_PREFIX=/opt/opencv \
         -DBUILD_LIST=core,imgproc,highgui,imgcodecs \
         -DBUILD_SHARED_LIBS=ON \
+        -DWITH_IPP=OFF \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} && \
     ninja -j$(nproc) && ninja install
 

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -27,8 +27,8 @@ RUN dpkg --add-architecture arm64 && \
 
 # Build and install OpenCV for ARM64
 WORKDIR /opt
-RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv_contrib.git && \
+RUN git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv_contrib.git && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -37,6 +37,7 @@ RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_opencv_legacy=OFF \
+        -DWITH_IPP=OFF \
         -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         ../opencv && \
     make -j$(nproc) && make install

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -27,8 +27,8 @@ RUN dpkg --add-architecture armhf && \
 
 # Build and install OpenCV for ARMv7
 WORKDIR /opt
-RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv_contrib.git && \
+RUN git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv_contrib.git && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -37,6 +37,7 @@ RUN git clone --depth 1 --branch 4.8.0 https://github.com/opencv/opencv.git && \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
         -DBUILD_opencv_legacy=OFF \
+        -DWITH_IPP=OFF \
         -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         ../opencv && \
     make -j$(nproc) && make install

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -35,12 +35,13 @@ ENV CXX=aarch64-linux-gnu-g++
 
 # Build OpenCV for the aarch64 sysroot
 WORKDIR /opt
-RUN git clone --depth 1 -b 4.8.1 https://github.com/opencv/opencv.git && \
+RUN git clone --depth 1 -b 4.11.0 https://github.com/opencv/opencv.git && \
     mkdir build && cd build && \
     cmake -G Ninja ../opencv \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
         -DBUILD_SHARED_LIBS=ON \
+        -DWITH_IPP=OFF \
         -DCMAKE_BUILD_TYPE=Release && \
     ninja -j$(nproc) && ninja install && \
     rm -rf /opt/opencv


### PR DESCRIPTION
## Summary
- update OpenCV to 4.11.0 in build Dockerfiles
- disable IPP during OpenCV build to avoid link errors

## Testing
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*
- `cargo test` *(fails: Could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683e5d0835a883219c2366c6198aba8c