### PR TITLE
Fix arm64 image apt sources

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    # cross-rs base images restrict apt to amd64 packages only. Remove the
+    # filter so we can fetch arm64 packages for the sysroot.
+    sed -i 's/\[arch=amd64\] //' /etc/apt/sources.list && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \


### PR DESCRIPTION
## Summary
- allow installing arm64 packages when building the `aarch64-opencv` image

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e7608a7508321a8a9d1d93cd55d7b