### PR TITLE
Fix arm64 package sources for aarch64 builder

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -17,6 +17,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    # cross-rs base images restrict apt to amd64 packages only. Retain the
+    # host repositories and add arm64 sources from the Ubuntu ports archive so
+    # we can fetch dependencies for the sysroot.
+    sed -Ei '/^deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe restricted\n' > /etc/apt/sources.list.d/arm64.list && \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe restricted\n' >> /etc/apt/sources.list.d/arm64.list && \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe restricted\n' >> /etc/apt/sources.list.d/arm64.list && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \


### PR DESCRIPTION
## Summary
- add Ubuntu ports repository for arm64 packages in the aarch64 OpenCV builder image

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e7608a7508321a8a9d1d93cd55d7b