### PR TITLE
Fix aarch64 image build

### DIFF
--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -17,6 +17,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    # cross-rs base images restrict apt to amd64 packages only. Retain the
+    # host repositories and add arm64 sources from the Ubuntu ports archive so
+    # we can fetch dependencies for the sysroot.
+    sed -Ei '/^deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe restricted\n' > /etc/apt/sources.list.d/arm64.list && \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe restricted\n' >> /etc/apt/sources.list.d/arm64.list && \
+    printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main universe restricted\n' >> /etc/apt/sources.list.d/arm64.list && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
@@ -26,7 +33,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
         cmake ninja-build git pkg-config \
         libgtk-3-dev:arm64 libjpeg-dev:arm64 libpng-dev:arm64 libtiff-dev:arm64 \
         libavcodec-dev:arm64 libavformat-dev:arm64 libswscale-dev:arm64 libv4l-dev:arm64 \
-        libxvidcore-dev:arm64 libx264-dev:arm64 gfortran:arm64 libtbb2:arm64 libtbb-dev:arm64 \
+        libxvidcore-dev:arm64 libx264-dev:arm64 libtbb2:arm64 libtbb-dev:arm64 \
         libatlas-base-dev:arm64 libdc1394-22-dev:arm64 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- remove `gfortran` from the aarch64 OpenCV builder image because it pulls in unsatisfiable dependencies

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo test` *(fails to download crates)*


------
https://chatgpt.com/codex/tasks/task_e_683e7608a7508321a8a9d1d93cd55d7b