### PR TITLE
Fix OpenCV vector alias imports

### DIFF
--- a/src/detection.rs
+++ b/src/detection.rs
@@ -6,9 +6,8 @@
 //! • returns contours, boxes, centres, annotated frame
 
 use opencv::{
-    core::{self, Mat, Point, Scalar, Size},
+    core::{self, Mat, Point, Scalar, Size, Vector},
     imgproc,
-    types::VectorOfVectorOfPoint,
     Result,
 };
 use std::collections::HashMap;
@@ -105,7 +104,7 @@ impl GreenOnBrown {
         algorithm: &str,
         invert_hue: bool,
         label: &str,
-    ) -> Result<(VectorOfVectorOfPoint, Vec<[i32; 4]>, Vec<[i32; 2]>, Mat)> {
+    ) -> Result<(Vector<Vector<Point>>, Vec<[i32; 4]>, Vec<[i32; 2]>, Mat)> {
         /* 1 ─ build mask */
         let (mut mask, already_thresh) = if let Some(f) = self.simple.get(algorithm) {
             (f(frame)?, false)
@@ -162,7 +161,7 @@ impl GreenOnBrown {
         }
 
         /* 3 ─ contours, boxes, centres */
-        let mut contours = VectorOfVectorOfPoint::new();
+        let mut contours: Vector<Vector<Point>> = Vector::new();
         imgproc::find_contours(
             &mask,
             &mut contours,

--- a/src/utils/algorithms.rs
+++ b/src/utils/algorithms.rs
@@ -1,7 +1,7 @@
 //! Lightweight vegetation-index helpers (no self-borrow conflicts).
 
 use opencv::{
-    core::{self, Mat, Scalar},
+    core::{self, Mat, Scalar, Vector},
     imgproc,
     prelude::*,
     Result,
@@ -9,7 +9,7 @@ use opencv::{
 
 /* helpers ───────────────────────────────────────────────────────────── */
 fn split_bgr(src: &Mat) -> Result<(Mat, Mat, Mat)> {
-    let mut v = opencv::types::VectorOfMat::new();
+    let mut v: Vector<Mat> = Vector::new();
     core::split(src, &mut v)?;
     Ok((v.get(0)?, v.get(1)?, v.get(2)?)) // (B,G,R)
 }


### PR DESCRIPTION
## Summary
- update detection to use generic `Vector` types
- fix algorithms module after opencv upgrade

## Testing
- `cargo check --locked` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_683f5dc142a8832181218bdb528a585a