### PR TITLE
Fix ARMv7 build packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: "latest"
-      DOCKERFILE_PATH: "docker/Dockerfile.armv7"
+      DOCKERFILE_PATH: "Dockerfile.armv7-opencv"
       GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
       TZ: Australia/Brisbane

--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -13,6 +13,8 @@ RUN apt-get update && \
 
 # Install required dependencies for OpenCV
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    dpkg --add-architecture armhf && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config pkg-config-arm-linux-gnueabihf \
@@ -20,6 +22,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
       libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
       openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
+      libunwind-dev \
       libdc1394-dev cmake git clang && \
     rm -rf /var/lib/apt/lists/*
 
@@ -60,6 +63,8 @@ RUN apt-get update && \
     dpkg-reconfigure -f noninteractive tzdata && \
     rm -rf /var/lib/apt/lists/*
 RUN rm -rf /etc/apt/sources.list.d/* && \
+    dpkg --add-architecture armhf && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config pkg-config-arm-linux-gnueabihf && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you prefer to build inside a container you can create the images used by
 docker build -f Dockerfile.pi-opencv -t ghcr.io/<your-namespace>/aarch64-opencv:latest .
 
 # For 32-bit ARM targets
-docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/<your-namespace>/armv7-opencv:latest .
+docker build -f Dockerfile.armv7-opencv -t ghcr.io/<your-namespace>/armv7-opencv:latest .
 ```
 
 These Dockerfiles install common build tools and now include


### PR DESCRIPTION
## Summary
- reference `Dockerfile.armv7-opencv` in docs and workflow
- install missing dependencies in `Dockerfile.armv7-opencv`

## Testing
- `cargo test` *(fails to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683fda743c988321b60c58864b931e24