### PR TITLE
Fix armv7 env handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: "latest"
-      DOCKERFILE_PATH: "docker/Dockerfile.armv7"
+      DOCKERFILE_PATH: "Dockerfile.armv7-opencv"
       GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
       TZ: Australia/Brisbane

--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -12,7 +12,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install required dependencies for OpenCV
-RUN rm -rf /etc/apt/sources.list.d/* && \
+RUN CODENAME=$(. /etc/os-release && echo $VERSION_CODENAME) && \
+    dpkg --add-architecture armhf && \
+    dpkg --remove-architecture i386 || true && \
+    sed -Ei '/^deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list && \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports %s main universe restricted\n' "$CODENAME" > /etc/apt/sources.list.d/armhf.list && \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports %s-updates main universe restricted\n' "$CODENAME" >> /etc/apt/sources.list.d/armhf.list && \
+    printf 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports %s-security main universe restricted\n' "$CODENAME" >> /etc/apt/sources.list.d/armhf.list && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
       pkg-config pkg-config-arm-linux-gnueabihf \
@@ -20,6 +26,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
       libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
       libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
       openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
+      libunwind-dev \
       libdc1394-dev cmake git clang && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,12 +65,11 @@ RUN apt-get update && \
     ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
     echo ${TZ} > /etc/timezone && \
     dpkg-reconfigure -f noninteractive tzdata && \
-    rm -rf /var/lib/apt/lists/*
-RUN rm -rf /etc/apt/sources.list.d/* && \
+    rm -rf /var/lib/apt/lists/* && \
+    dpkg --add-architecture armhf && \
+    dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config pkg-config-arm-linux-gnueabihf && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
-ENV LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib
-ENV LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you prefer to build inside a container you can create the images used by
 docker build -f Dockerfile.pi-opencv -t ghcr.io/<your-namespace>/aarch64-opencv:latest .
 
 # For 32-bit ARM targets
-docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/<your-namespace>/armv7-opencv:latest .
+docker build -f Dockerfile.armv7-opencv -t ghcr.io/<your-namespace>/armv7-opencv:latest .
 ```
 
 These Dockerfiles install common build tools and now include


### PR DESCRIPTION
## Summary
- drop LIBRARY_PATH and LD_LIBRARY_PATH from the armv7 image to avoid host link errors

## Testing
- `cargo fmt --all` *(failed: rustfmt component missing)*
- `cargo test` *(failed to download crates)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683fda743c988321b60c58864b931e24