### PR TITLE
Fix armv7 OpenCV build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: "latest"
-      DOCKERFILE_PATH: "docker/Dockerfile.armv7"
+      DOCKERFILE_PATH: "Dockerfile.armv7-opencv"
       GHCR_USER: ${{ github.repository_owner }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
       TZ: Australia/Brisbane

--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -1,4 +1,9 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS builder
+# ------------------------------------------------------------
+# Stage 1 - Build OpenCV for armv7
+# ------------------------------------------------------------
+ARG OPENCV_VERSION=4.10.0
+ARG CMAKE_BUILD_TYPE=Release
+FROM ubuntu:22.04 AS opencv-build
 
 # Configure tzdata non-interactively to avoid prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,58 +17,68 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install required dependencies for OpenCV
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 install -y \
-      pkg-config pkg-config-arm-linux-gnueabihf \
-      libgtk-3-dev \
-      libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
-      libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev gfortran \
-      openexr libatlas-base-dev python3-dev python3-numpy libtbb2 libtbb-dev \
-      libdc1394-dev cmake git clang && \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+        cmake ninja-build git pkg-config \
+        libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
+        libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+        libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
+        libatlas-base-dev libdc1394-22-dev libunwind-dev \
+        python3-dev python3-numpy && \
     rm -rf /var/lib/apt/lists/*
+
+ENV CC=arm-linux-gnueabihf-gcc
+ENV CXX=arm-linux-gnueabihf-g++
 
 # Build and install OpenCV for ARMv7
 WORKDIR /opt
-RUN git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv_contrib.git && \
-    mkdir -p build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DOPENCV_GENERATE_PKGCONFIG=ON \
+RUN git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/opencv_contrib.git && \
+    mkdir build && cd build && \
+    cmake -G Ninja ../opencv \
+        -DCMAKE_INSTALL_PREFIX=/opt/opencv \
+        -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_IPP=OFF \
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DOPENCV_EXTRA_MODULES_PATH=/opt/opencv_contrib/modules \
+        -DOPENCV_GENERATE_PKGCONFIG=ON \
         -DOPENCV_ENABLE_NONFREE=ON \
         -DENABLE_PRECOMPILED_HEADERS=OFF \
-        -DBUILD_opencv_legacy=OFF \
-        -DWITH_IPP=OFF \
-        -DBUILD_LIST=core,imgproc,highgui,imgcodecs,videoio,objdetect \
-        ../opencv && \
-    make -j$(nproc) && make install
+        -DBUILD_opencv_legacy=OFF && \
+    ninja -j$(nproc) && ninja install
 
 # Copy OpenCV libraries and pkg-config file to sysroot
 RUN mkdir -p /arm-linux-gnueabihf/lib && \
-    cp -r /usr/local/lib/* /arm-linux-gnueabihf/lib/ && \
+    cp -r /opt/opencv/lib/* /arm-linux-gnueabihf/lib/ && \
     mkdir -p /arm-linux-gnueabihf/include && \
-    cp -r /usr/local/include/* /arm-linux-gnueabihf/include/ && \
+    cp -r /opt/opencv/include/* /arm-linux-gnueabihf/include/ && \
     mkdir -p /arm-linux-gnueabihf/lib/pkgconfig && \
-    cp /usr/local/lib/pkgconfig/opencv4.pc /arm-linux-gnueabihf/lib/pkgconfig/
+    cp /opt/opencv/lib/pkgconfig/opencv4.pc /arm-linux-gnueabihf/lib/pkgconfig/ && \
+    sed -i 's|^prefix=.*|prefix=/usr/arm-linux-gnueabihf|' /arm-linux-gnueabihf/lib/pkgconfig/opencv4.pc
 
-# Final image: will be used by cross
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=Australia/Brisbane
+# ------------------------------------------------------------
+# Stage 2 - Build Rust project using cross
+# ------------------------------------------------------------
+ARG RUST_TOOLCHAIN=stable
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS rust-build
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends tzdata && \
-    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
-    echo ${TZ} > /etc/timezone && \
-    dpkg-reconfigure -f noninteractive tzdata && \
-    rm -rf /var/lib/apt/lists/*
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config pkg-config-arm-linux-gnueabihf && \
-    rm -rf /var/lib/apt/lists/*
-COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
-ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
-ENV LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib
-ENV LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib
+RUN rustup default ${RUST_TOOLCHAIN}
+RUN cargo install --git https://github.com/cross-rs/cross cross --locked
+
+COPY --from=opencv-build /opt/opencv /opt/opencv
+ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig
+
+WORKDIR /workspace
+COPY . /workspace
+
+RUN cross build --release --target armv7-unknown-linux-gnueabihf
+
+# ------------------------------------------------------------
+# Stage 3 - Runtime image
+# ------------------------------------------------------------
+FROM ubuntu:22.04 AS runtime
+COPY --from=opencv-build /opt/opencv /opt/opencv
+COPY --from=rust-build /workspace/target/armv7-unknown-linux-gnueabihf/release/rustspray /usr/local/bin/rustspray
+ENV LD_LIBRARY_PATH=/opt/opencv/lib
+CMD ["/usr/local/bin/rustspray"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you prefer to build inside a container you can create the images used by
 docker build -f Dockerfile.pi-opencv -t ghcr.io/<your-namespace>/aarch64-opencv:latest .
 
 # For 32-bit ARM targets
-docker build -f Dockerfile.pi-opencv-armv7 -t ghcr.io/<your-namespace>/armv7-opencv:latest .
+docker build -f Dockerfile.armv7-opencv -t ghcr.io/<your-namespace>/armv7-opencv:latest .
 ```
 
 These Dockerfiles install common build tools and now include


### PR DESCRIPTION
## Summary
- rebuild OpenCV for armv7 using an Ubuntu toolchain stage
- compile Rust using cross with the rebuilt OpenCV sysroot
- run binaries from a minimal runtime image
- reference the correct Dockerfile in docs and CI

## Testing
- `cargo fmt --all` *(failed: rustfmt component missing)*
- `cargo test` *(failed to download crates)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683fda743c988321b60c58864b931e24