### PR TITLE
Fix cross compile docker build

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev libunwind-dev \
+        libatlas-base-dev libdc1394-dev libunwind-dev \
         python3-dev python3-numpy && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,13 +58,9 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
     sed -i 's|^prefix=.*|prefix=/usr/arm-linux-gnueabihf|' /arm-linux-gnueabihf/lib/pkgconfig/opencv4.pc
 
 # ------------------------------------------------------------
-# Stage 2 - Build Rust project using cross
+# Stage 2 - Build Rust project
 # ------------------------------------------------------------
-ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS rust-build
-
-RUN rustup default ${RUST_TOOLCHAIN}
-RUN cargo install --git https://github.com/cross-rs/cross cross --locked
 
 COPY --from=opencv-build /opt/opencv /opt/opencv
 ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig
@@ -72,7 +68,7 @@ ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig
 WORKDIR /workspace
 COPY . /workspace
 
-RUN cross build --release --target armv7-unknown-linux-gnueabihf
+RUN cargo build --release --target armv7-unknown-linux-gnueabihf
 
 # ------------------------------------------------------------
 # Stage 3 - Runtime image

--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev && \
+        libatlas-base-dev libdc1394-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CC=aarch64-linux-gnu-gcc
@@ -44,15 +44,9 @@ RUN git clone --depth 1 -b ${OPENCV_VERSION} https://github.com/opencv/opencv.gi
     ninja -j$(nproc) && ninja install
 
 # ------------------------------------------------------------
-# Stage 2 - Build Rust project using cross
+# Stage 2 - Build Rust project
 # ------------------------------------------------------------
-ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS rust-build
-
-RUN rustup default ${RUST_TOOLCHAIN}
-
-# Install cross inside the container
-RUN cargo install --git https://github.com/cross-rs/cross cross --locked
 
 COPY --from=opencv-build /opt/opencv /opt/opencv
 ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig
@@ -60,7 +54,7 @@ ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig
 WORKDIR /workspace
 COPY . /workspace
 
-RUN cross build --release --target aarch64-unknown-linux-gnu
+RUN cargo build --release --target aarch64-unknown-linux-gnu
 
 # ------------------------------------------------------------
 # Stage 3 - Runtime image

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -40,7 +40,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
         libgtk-3-dev:arm64 libjpeg-dev:arm64 libpng-dev:arm64 libtiff-dev:arm64 \
         libavcodec-dev:arm64 libavformat-dev:arm64 libswscale-dev:arm64 libv4l-dev:arm64 \
         libxvidcore-dev:arm64 libx264-dev:arm64 libtbb2:arm64 libtbb-dev:arm64 \
-        libatlas-base-dev:arm64 libdc1394-22-dev:arm64 && \
+        libatlas-base-dev:arm64 libdc1394-dev:arm64 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CC=aarch64-linux-gnu-gcc


### PR DESCRIPTION
## Summary
- fix package names for libdc1394 on Ubuntu 22.04
- drop rustup and cross usage from Dockerfiles and compile directly with cargo

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo test` *(fails to download dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6844a4a407248321ab54c18d5b13f52f