### PR TITLE
Fix cross compile docker build

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev libunwind-dev \
+        libatlas-base-dev libdc1394-dev libunwind-dev \
         python3-dev python3-numpy && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,13 +58,18 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
     sed -i 's|^prefix=.*|prefix=/usr/arm-linux-gnueabihf|' /arm-linux-gnueabihf/lib/pkgconfig/opencv4.pc
 
 # ------------------------------------------------------------
-# Stage 2 - Build Rust project using cross
+# Stage 2 - Build Rust project
 # ------------------------------------------------------------
 ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS rust-build
 
-RUN rustup default ${RUST_TOOLCHAIN}
-RUN cargo install --git https://github.com/cross-rs/cross cross --locked
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
+    /root/.cargo/bin/cargo install --git https://github.com/cross-rs/cross cross --locked
+
+ENV PATH=/root/.cargo/bin:$PATH
 
 COPY --from=opencv-build /opt/opencv /opt/opencv
 ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig

--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev && \
+        libatlas-base-dev libdc1394-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CC=aarch64-linux-gnu-gcc
@@ -44,15 +44,18 @@ RUN git clone --depth 1 -b ${OPENCV_VERSION} https://github.com/opencv/opencv.gi
     ninja -j$(nproc) && ninja install
 
 # ------------------------------------------------------------
-# Stage 2 - Build Rust project using cross
+# Stage 2 - Build Rust project
 # ------------------------------------------------------------
 ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS rust-build
 
-RUN rustup default ${RUST_TOOLCHAIN}
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
+    /root/.cargo/bin/cargo install --git https://github.com/cross-rs/cross cross --locked
 
-# Install cross inside the container
-RUN cargo install --git https://github.com/cross-rs/cross cross --locked
+ENV PATH=/root/.cargo/bin:$PATH
 
 COPY --from=opencv-build /opt/opencv /opt/opencv
 ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -40,7 +40,7 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
         libgtk-3-dev:arm64 libjpeg-dev:arm64 libpng-dev:arm64 libtiff-dev:arm64 \
         libavcodec-dev:arm64 libavformat-dev:arm64 libswscale-dev:arm64 libv4l-dev:arm64 \
         libxvidcore-dev:arm64 libx264-dev:arm64 libtbb2:arm64 libtbb-dev:arm64 \
-        libatlas-base-dev:arm64 libdc1394-22-dev:arm64 && \
+        libatlas-base-dev:arm64 libdc1394-dev:arm64 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CC=aarch64-linux-gnu-gcc


### PR DESCRIPTION
## Summary
- install missing Rust toolchain in Dockerfiles that use the cross images
- keep package names for libdc1394 on Ubuntu 22.04

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' is not installed)*
- `cargo test` *(fails to download dependencies)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6844a4a407248321ab54c18d5b13f52f