### PR TITLE
Fix cross compile docker build

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev libunwind-dev \
+        libatlas-base-dev libdc1394-dev libunwind-dev \
         python3-dev python3-numpy && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,13 +58,20 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
     sed -i 's|^prefix=.*|prefix=/usr/arm-linux-gnueabihf|' /arm-linux-gnueabihf/lib/pkgconfig/opencv4.pc
 
 # ------------------------------------------------------------
-# Stage 2 - Build Rust project using cross
+# Stage 2 - Build Rust project
 # ------------------------------------------------------------
 ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS rust-build
+ARG RUST_TOOLCHAIN
 
-RUN rustup default ${RUST_TOOLCHAIN}
-RUN cargo install --git https://github.com/cross-rs/cross cross --locked
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl https://sh.rustup.rs -sSf | \
+        sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable} && \
+    /root/.cargo/bin/cargo install --git https://github.com/cross-rs/cross cross --locked
+
+ENV PATH=/root/.cargo/bin:$PATH
 
 COPY --from=opencv-build /opt/opencv /opt/opencv
 ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig

--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -48,8 +48,9 @@ RUN git clone --depth 1 -b ${OPENCV_VERSION} https://github.com/opencv/opencv.gi
 # ------------------------------------------------------------
 ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main AS rust-build
+ARG RUST_TOOLCHAIN
 
-RUN rustup default ${RUST_TOOLCHAIN}
+RUN rustup default ${RUST_TOOLCHAIN:-stable}
 
 # Install cross inside the container
 RUN cargo install --git https://github.com/cross-rs/cross cross --locked


### PR DESCRIPTION
## Summary
- ensure `RUST_TOOLCHAIN` argument is passed correctly to rustup in the ARMv7 Dockerfile
- declare the same argument in the aarch64 build stage

## Testing
- `cargo fmt --all` *(failed: 'cargo-fmt' is not installed)*
- `cargo test` *(failed to download dependencies)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6844a4a407248321ab54c18d5b13f52f