### PR TITLE
Fix cross compile docker build

### DIFF
--- a/Dockerfile.armv7-opencv
+++ b/Dockerfile.armv7-opencv
@@ -1,9 +1,11 @@
 # ------------------------------------------------------------
 # Stage 1 - Build OpenCV for armv7
 # ------------------------------------------------------------
-ARG OPENCV_VERSION=4.10.0
+ARG OPENCV_VERSION=4.11.0
 ARG CMAKE_BUILD_TYPE=Release
 FROM ubuntu:22.04 AS opencv-build
+ARG OPENCV_VERSION
+ARG CMAKE_BUILD_TYPE
 
 # Configure tzdata non-interactively to avoid prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -18,12 +20,13 @@ RUN apt-get update && \
 
 # Install required dependencies for OpenCV
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
         gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
         cmake ninja-build git pkg-config \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev libunwind-dev \
+        libatlas-base-dev libdc1394-dev libunwind-dev \
         python3-dev python3-numpy && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,13 +61,21 @@ RUN mkdir -p /arm-linux-gnueabihf/lib && \
     sed -i 's|^prefix=.*|prefix=/usr/arm-linux-gnueabihf|' /arm-linux-gnueabihf/lib/pkgconfig/opencv4.pc
 
 # ------------------------------------------------------------
-# Stage 2 - Build Rust project using cross
+# Stage 2 - Build Rust project
 # ------------------------------------------------------------
 ARG RUST_TOOLCHAIN=stable
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge AS rust-build
+ARG RUST_TOOLCHAIN
 
-RUN rustup default ${RUST_TOOLCHAIN}
-RUN cargo install --git https://github.com/cross-rs/cross cross --locked
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl https://sh.rustup.rs -sSf | \
+        sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN:-stable} && \
+    /root/.cargo/bin/cargo install --git https://github.com/cross-rs/cross cross --locked
+
+ENV PATH=/root/.cargo/bin:$PATH
 
 COPY --from=opencv-build /opt/opencv /opt/opencv
 ENV PKG_CONFIG_PATH=/opt/opencv/lib/pkgconfig

--- a/Dockerfile.cross-aarch64
+++ b/Dockerfile.cross-aarch64
@@ -4,9 +4,11 @@
 # ------------------------------------------------------------
 # Stage 1 - Build OpenCV for aarch64
 # ------------------------------------------------------------
-ARG OPENCV_VERSION=4.10.0
+ARG OPENCV_VERSION=4.11.0
 ARG CMAKE_BUILD_TYPE=Release
 FROM ubuntu:22.04 AS opencv-build
+ARG OPENCV_VERSION
+ARG CMAKE_BUILD_TYPE
 
 # Configure tzdata non-interactively so builds do not block waiting for
 # timezone selection when any package pulls it in as a dependency.
@@ -21,12 +23,13 @@ RUN apt-get update && \
 
 # Install cross compile toolchain and build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         cmake ninja-build git pkg-config \
         libgtk-3-dev libjpeg-dev libpng-dev libtiff-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
         libxvidcore-dev libx264-dev gfortran libtbb2 libtbb-dev \
-        libatlas-base-dev libdc1394-22-dev && \
+        libatlas-base-dev libdc1394-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CC=aarch64-linux-gnu-gcc

--- a/Dockerfile.pi-opencv
+++ b/Dockerfile.pi-opencv
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
+        ca-certificates \
         pkg-config \
         libgtk-3-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
@@ -27,8 +28,8 @@ RUN dpkg --add-architecture arm64 && \
 
 # Build and install OpenCV for ARM64
 WORKDIR /opt
-RUN git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv_contrib.git && \
+RUN git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv_contrib.git && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -64,7 +65,7 @@ RUN apt-get update && \
     dpkg --add-architecture arm64 && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config && \
+    apt-get -o Acquire::Retries=3 --fix-missing install -y ca-certificates pkg-config && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /aarch64-linux-gnu /usr/aarch64-linux-gnu
 ENV PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig

--- a/Dockerfile.pi-opencv-armv7
+++ b/Dockerfile.pi-opencv-armv7
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture armhf && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y \
+        ca-certificates \
         pkg-config pkg-config-arm-linux-gnueabihf \
         libgtk-3-dev \
         libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
@@ -27,8 +28,8 @@ RUN dpkg --add-architecture armhf && \
 
 # Build and install OpenCV for ARMv7
 WORKDIR /opt
-RUN git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv_contrib.git && \
+RUN git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git && \
+    git clone --depth 1 --branch 4.11.0 https://github.com/opencv/opencv_contrib.git && \
     mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -64,7 +65,7 @@ RUN apt-get update && \
 RUN dpkg --add-architecture armhf && \
     dpkg --remove-architecture i386 || true && \
     apt-get -o Acquire::Retries=3 update && \
-    apt-get -o Acquire::Retries=3 --fix-missing install -y pkg-config pkg-config-arm-linux-gnueabihf && \
+    apt-get -o Acquire::Retries=3 --fix-missing install -y ca-certificates pkg-config pkg-config-arm-linux-gnueabihf && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /arm-linux-gnueabihf /usr/arm-linux-gnueabihf
 ENV PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig

--- a/docker/aarch64-opencv.dockerfile
+++ b/docker/aarch64-opencv.dockerfile
@@ -34,13 +34,14 @@ RUN rm -rf /etc/apt/sources.list.d/* && \
     add-apt-repository universe && \
     apt-get -o Acquire::Retries=3 update && \
     apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        ca-certificates \
         build-essential \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         cmake ninja-build git pkg-config clang \
         libgtk-3-dev:arm64 libjpeg-dev:arm64 libpng-dev:arm64 libtiff-dev:arm64 \
         libavcodec-dev:arm64 libavformat-dev:arm64 libswscale-dev:arm64 libv4l-dev:arm64 \
         libxvidcore-dev:arm64 libx264-dev:arm64 libtbb2:arm64 libtbb-dev:arm64 \
-        libatlas-base-dev:arm64 libdc1394-22-dev:arm64 && \
+        libatlas-base-dev:arm64 libdc1394-dev:arm64 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CC=aarch64-linux-gnu-gcc
@@ -48,7 +49,7 @@ ENV CXX=aarch64-linux-gnu-g++
 
 # Build OpenCV for the aarch64 sysroot
 WORKDIR /opt
-RUN git clone --depth 1 -b 4.10.0 https://github.com/opencv/opencv.git && \
+RUN git clone --depth 1 -b 4.11.0 https://github.com/opencv/opencv.git && \
     mkdir build && cd build && \
     cmake -G Ninja ../opencv \
         -DCMAKE_INSTALL_PREFIX=/usr/local \


### PR DESCRIPTION
## Summary
- ensure `OPENCV_VERSION` and `CMAKE_BUILD_TYPE` args are visible in OpenCV build stages
- bump OpenCV to 4.11
- revert unintended changes to the aarch64 Dockerfile
- install ca-certificates so git clone succeeds

## Testing
- `cargo fmt --all` *(failed: 'cargo-fmt' is not installed)*
- `cargo test` *(failed to download dependencies)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6844a4a407248321ab54c18d5b13f52f