### PR TITLE
Add documentation for public APIs

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -18,6 +18,14 @@ pub struct Camera {
 }
 
 impl Camera {
+    /// Create a new camera instance.
+    ///
+    /// If `use_rpi` is `true` the Raspberry Pi camera backend is selected when the
+    /// `picam` feature is enabled. Otherwise OpenCV's `VideoCapture` is used.
+    ///
+    /// # Errors
+    /// Returns an error if the backend cannot be initialised or the feature is
+    /// not available.
     pub fn new(device: &str, width: u32, height: u32, use_rpi: bool) -> Result<Self, Box<dyn Error>> {
         if use_rpi {
             #[cfg(feature = "picam")]
@@ -45,6 +53,10 @@ impl Camera {
         Ok(Camera { backend: CameraBackend::OpenCv(capture) })
     }
 
+    /// Capture a frame from the configured backend.
+    ///
+    /// # Errors
+    /// Returns an error if a frame could not be captured from the camera.
     pub fn capture(&mut self) -> Result<Mat, Box<dyn Error>> {
         match &mut self.backend {
             CameraBackend::OpenCv(cap) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,10 @@ pub struct Config {
 }
 
 impl Config {
+    /// Load configuration from the given TOML file path.
+    ///
+    /// # Errors
+    /// Returns [`ConfigError`] if the file cannot be read or parsed.
     pub fn load(path: &str) -> Result<Self, ConfigError> {
         let contents = fs::read_to_string(path)?;
         Ok(toml::from_str(&contents)?)

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -48,6 +48,7 @@ fn hsv_wrapper(
 
 /* ───────────────────────── struct ───────────────────────── */
 
+/// Detection utilities for segmenting green weeds against brown soil.
 pub struct GreenOnBrown {
     kernel: Mat,
     simple: HashMap<String, AlgFn>,
@@ -55,6 +56,10 @@ pub struct GreenOnBrown {
 }
 
 impl GreenOnBrown {
+    /// Create a new detector using `default_alg` as the initial algorithm.
+    ///
+    /// # Errors
+    /// Returns an `opencv::Error` if the algorithm name is unknown.
     pub fn new(default_alg: &str) -> Result<Self> {
         let kernel = imgproc::get_structuring_element(
             imgproc::MORPH_ELLIPSE,
@@ -88,6 +93,13 @@ impl GreenOnBrown {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Run the detection pipeline on a frame.
+    ///
+    /// Returns the raw contours, bounding boxes, centre points and an
+    /// annotated frame.
+    ///
+    /// # Errors
+    /// Propagates errors from the underlying OpenCV calls.
     pub fn inference(
         &self,
         frame: &Mat,

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 // ─── processing loop ────────────────────────────────────────────────────────
+/// Execute the camera/detection/spray loop until `q` is pressed if the display
+/// window is shown.
 fn run(
     camera: &mut Camera,
     gob: &GreenOnBrown,

--- a/src/picam.rs
+++ b/src/picam.rs
@@ -2,11 +2,14 @@ use opencv::{imgcodecs, core::{self, Vector}, prelude::*};
 use rscam::{Camera as PiCamera, Config as PiConfig};
 use std::error::Error;
 
+/// Thin wrapper around `rscam` for capturing MJPEG frames from the
+/// Raspberry Pi camera.
 pub struct Picam {
     camera: PiCamera,
 }
 
 impl Picam {
+    /// Create and configure a new Raspberry Pi camera instance.
     pub fn new(device: &str, width: u32, height: u32) -> Result<Self, Box<dyn Error>> {
         let mut cam = PiCamera::new(device)?;
         cam.start(&PiConfig {
@@ -18,6 +21,7 @@ impl Picam {
         Ok(Picam { camera: cam })
     }
 
+    /// Capture a single frame from the camera.
     pub fn capture(&mut self) -> Result<Mat, Box<dyn Error>> {
         let frame = self.camera.capture()?;
         let data = Vector::from_slice(&frame);

--- a/src/spray.rs
+++ b/src/spray.rs
@@ -15,20 +15,24 @@ pub struct Sprayer {
 }
 
 impl Sprayer {
+    /// Create a new sprayer attached to the given GPIO pin.
     pub fn new(pin_num: u8) -> Result<Self, SprayError> {
         let gpio = Gpio::new()?;
         let pin = gpio.get(pin_num)?.into_output();
         Ok(Sprayer { pin })
     }
 
+    /// Set the GPIO pin high to activate the sprayer.
     pub fn activate(&mut self) {
         self.pin.set_high();
     }
 
+    /// Set the GPIO pin low to deactivate the sprayer.
     pub fn deactivate(&mut self) {
         self.pin.set_low();
     }
 
+    /// Pulse the sprayer for the specified duration.
     pub fn pulse(&mut self, duration: Duration) {
         self.activate();
         std::thread::sleep(duration);
@@ -41,6 +45,7 @@ pub struct SprayController {
 }
 
 impl SprayController {
+    /// Create a controller for four sprayers using the supplied GPIO pins.
     pub fn new(pins: [u8; 4]) -> Result<Self, SprayError> {
         let sprayer0 = Sprayer::new(pins[0])?;
         let sprayer1 = Sprayer::new(pins[1])?;
@@ -51,6 +56,7 @@ impl SprayController {
         })
     }
 
+    /// Activate a specific sprayer by index.
     pub fn activate_sprayer(&mut self, index: usize) -> Result<(), SprayError> {
         if index < 4 {
             self.sprayers[index].activate();
@@ -60,6 +66,7 @@ impl SprayController {
         }
     }
 
+    /// Deactivate a specific sprayer by index.
     pub fn deactivate_sprayer(&mut self, index: usize) -> Result<(), SprayError> {
         if index < 4 {
             self.sprayers[index].deactivate();
@@ -69,6 +76,7 @@ impl SprayController {
         }
     }
 
+    /// Pulse a specific sprayer for a duration.
     pub fn pulse_sprayer(&mut self, index: usize, duration: Duration) -> Result<(), SprayError> {
         if index < 4 {
             self.sprayers[index].pulse(duration);
@@ -78,12 +86,14 @@ impl SprayController {
         }
     }
 
+    /// Activate all sprayers simultaneously.
     pub fn activate_all(&mut self) {
         for sprayer in &mut self.sprayers {
             sprayer.activate();
         }
     }
 
+    /// Deactivate all sprayers.
     pub fn deactivate_all(&mut self) {
         for sprayer in &mut self.sprayers {
             sprayer.deactivate();


### PR DESCRIPTION
## Summary
- add rustdoc comments for major public functions and structs

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684494e06c2c8321a24f58ece70dd9d1