### PR TITLE
Fix release asset upload permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
+      packages: read
     needs: [build-aarch64-image, build-armv7]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- add job-level permissions in build workflow to allow writing release assets

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f2a535c8321b82ecea3ce0012e3