### PR TITLE
Add Nicholas Bass as main contact

### DIFF
--- a/CONTACT_NICHOLASBASS_EMAIL.md
+++ b/CONTACT_NICHOLASBASS_EMAIL.md
@@ -1,0 +1,13 @@
+Subject: Inquiry about Rust-Spray Collaboration
+To: nicholasbass@crop-crusaders.com
+
+Dear Nicholas,
+
+I hope this message finds you well. I am reaching out regarding the Rust-Spray project hosted at Crop Crusaders. I am interested in collaborating and learning more about the current development plans.
+
+Could we schedule a short call or continue the conversation via email to discuss potential contributions?
+
+Thank you for your time and I look forward to hearing from you.
+
+Best regards,
+[Your Name]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ raspberry-pi = ["with-rppal", "picam"]
 
 # ─────────────────────────────────────────────────────────────────────────────
 [package.metadata.deb]
-maintainer = "Crop Crusaders <dev@cropcrusaders.com>"
+maintainer = "Nicholas Bass <nicholasbass@crop-crusaders.com>"
 license-file = ["LICENSE"]
 depends = "libc6"
 assets = [

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ The program opens the camera, runs the detection algorithm and pulses the spraye
 
 Rust-Spray is released under the MIT license.
 
+## Contact
+
+For all inquiries about Rust-Spray please email
+[nicholasbass@crop-crusaders.com](mailto:nicholasbass@crop-crusaders.com).
+
+
 ## Yocto Build
 
 A minimal Yocto configuration is provided in the `yocto/` directory. It builds


### PR DESCRIPTION
## Summary
- update CONTACT_NICHOLASBASS_EMAIL.md with the proper recipient address
- mark Nicholas Bass as maintainer in Cargo.toml
- add a contact section in the README

## Testing
- `cargo fmt`
- `cargo test --features host`


------
https://chatgpt.com/codex/tasks/task_e_6869da62f5148321809bccd55a6573f2