### PR TITLE
Add Help section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,3 +271,11 @@ bitbake rust-spray-image
 ```
 
 See `yocto/README.md` for more details.
+
+## Help
+
+- 📋 GitHub Issues: Bug reports and feature requests
+- 💬 Discussions: Community Q&A and project discussions
+- 🌐 Discord: Join our community for real-time chat and support
+- 📧 Email Support: nicholasbass@crop-crusaders.com (security issues)
+- 📚 Documentation: Comprehensive guides in /docs directory

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# Documentation\n\nRefer to the [DOCUMENTATION_INDEX.md](../DOCUMENTATION_INDEX.md) file for a list of all guides.


### PR DESCRIPTION
## Summary
- add a Help section with support links
- start a docs directory referencing DOCUMENTATION_INDEX

## Testing
- `cargo fmt`
- `cargo test` *(fails: use of unresolved crate `opencv`)*

------
https://chatgpt.com/codex/tasks/task_e_686af33f36648321ba433e843bfe90f4