### PR TITLE
Fix CI dependencies for camera features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libglib2.0-dev \
+            libudev-dev \
+            libv4l-dev
       - run: cargo fmt --all -- --check
+      - run: cargo +nightly check --no-default-features --features camera-nokhwa
+      - run: cargo +nightly check --no-default-features --features camera-gstreamer
       - run: cargo +nightly build --release
       - run: cargo +nightly test
       - run: cargo +nightly run --example four_lane -- --mock-gpio


### PR DESCRIPTION
## Summary
- install the Linux development packages required by the optional camera backends before running cargo commands
- extend the workflow to check that the nokhwa and gstreamer camera feature sets compile

## Testing
- cargo fmt --all -- --check
- cargo test
- cargo check --no-default-features --features camera-nokhwa
- cargo check --no-default-features --features camera-gstreamer
- cargo run --example four_lane -- --mock-gpio

------
https://chatgpt.com/codex/tasks/task_e_68d08d47c290832185de5a9cff5f8b29