### PR TITLE
Fix CI workflow: add rustfmt component and remove redundant +nightly flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -21,10 +23,10 @@ jobs:
             libudev-dev \
             libv4l-dev
       - run: cargo fmt --all -- --check
-      - run: cargo +nightly check --no-default-features --features camera-nokhwa
-      - run: cargo +nightly check --no-default-features --features camera-gstreamer
-      - run: cargo +nightly build --release
-      - run: cargo +nightly test
-      - run: cargo +nightly run --example four_lane -- --mock-gpio
+      - run: cargo check --no-default-features --features camera-nokhwa
+      - run: cargo check --no-default-features --features camera-gstreamer
+      - run: cargo build --release
+      - run: cargo test
+      - run: cargo run --example four_lane -- --mock-gpio
       - name: Test production binary (test-pattern oneshot)
-        run: cargo +nightly run --release -- --test-pattern --mock-gpio --oneshot
+        run: cargo run --release -- --test-pattern --mock-gpio --oneshot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Rust-Spray is a minimal four-lane spray pipeline for agricultural robotics. It p
 # Standard build (nightly required)
 cargo build --release
 
-# Run all unit tests (10 tests)
+# Run all unit tests
 cargo test
 
 # Run the demo example
@@ -45,6 +45,7 @@ CI runs on every push and pull request (`.github/workflows/ci.yml`). The full pi
 4. `cargo build --release` — release build must succeed
 5. `cargo test` — all tests must pass
 6. `cargo run --example four_lane -- --mock-gpio` — example must run
+7. `cargo run --release -- --test-pattern --mock-gpio --oneshot` — production binary must run
 
 Always run `cargo fmt` and `cargo test` before committing.
 
@@ -198,8 +199,9 @@ cargo install --git https://github.com/cross-rs/cross cross --locked
 
 ## Testing
 
-All 10 unit tests live alongside their modules:
+All unit tests live alongside their modules:
 
+- `config.rs`: 3 tests (sane defaults, partial TOML, full round-trip)
 - `exg.rs`: 2 tests (green detection, non-green rejection)
 - `vision.rs`: 3 tests (bright green, dry soil, weight overrides)
 - `lanes.rs`: 5 tests (hysteresis, zero-lanes panic, edge cases)


### PR DESCRIPTION
The dtolnay/rust-toolchain@nightly action sets nightly as the default
toolchain, making +nightly prefixes on cargo commands redundant. More
importantly, rustfmt is not guaranteed to ship with every nightly, so
it must be explicitly requested as a component.

Also update CLAUDE.md to document the production binary CI step and
the config module tests.

https://claude.ai/code/session_01VRpshYbMn5QbD4EGRPS8ws