### PR TITLE
Replace dtolnay/rust-toolchain with rustup commands in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
+      - name: Install nightly toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --component rustfmt
+          rustup default nightly
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
The dtolnay/rust-toolchain action is not allowed by the cropcrusaders
org policy (must be org-owned, GitHub-created, or Marketplace-verified).
Replace it with direct rustup commands which are pre-installed on
GitHub-hosted runners.

https://claude.ai/code/session_01F8CXy4WxHpqC2MdkgphJPB