### PR TITLE
Fix SIMD channel deinterleave bug and harden Raspberry Pi deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo check --no-default-features --features camera-nokhwa
       - run: cargo check --no-default-features --features camera-gstreamer
+      - name: Check rpi feature (desktop fallback)
+        run: cargo check --features rpi
+      - name: Check Raspberry Pi targets (real GPIO)
+        run: |
+          rustup target add aarch64-unknown-linux-gnu armv7-unknown-linux-gnueabihf
+          cargo check --target aarch64-unknown-linux-gnu --features rpi
+          cargo check --target armv7-unknown-linux-gnueabihf --features rpi
       - run: cargo build --release
       - run: cargo test
       - run: cargo run --example four_lane -- --mock-gpio

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "yocto/poky"]
-path = yocto/poky
-url = https://git.yoctoproject.org/git/poky

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ cargo check --no-default-features --features camera-gstreamer
 
 # Cross-compile for Raspberry Pi (requires `cross` tool + Docker)
 cross build --release --target aarch64-unknown-linux-gnu --features rpi
-cross build --release --target armv7-unknown-linux-gnueabihf
+cross build --release --target armv7-unknown-linux-gnueabihf --features rpi
 ```
 
 ## CI Pipeline
@@ -42,10 +42,12 @@ CI runs on every push and pull request (`.github/workflows/ci.yml`). The full pi
 1. `cargo fmt --all -- --check` — formatting must pass
 2. `cargo check` with `camera-nokhwa` feature — must compile
 3. `cargo check` with `camera-gstreamer` feature — must compile
-4. `cargo build --release` — release build must succeed
-5. `cargo test` — all tests must pass
-6. `cargo run --example four_lane -- --mock-gpio` — example must run
-7. `cargo run --release -- --test-pattern --mock-gpio --oneshot` — production binary must run
+4. `cargo check --features rpi` — desktop fallback path must compile
+5. `cargo check --target aarch64-unknown-linux-gnu --features rpi` and `cargo check --target armv7-unknown-linux-gnueabihf --features rpi` — real GPIO code must compile for both Raspberry Pi targets
+6. `cargo build --release` — release build must succeed
+7. `cargo test` — all tests must pass
+8. `cargo run --example four_lane -- --mock-gpio` — example must run
+9. `cargo run --release -- --test-pattern --mock-gpio --oneshot` — production binary must run
 
 Always run `cargo fmt` and `cargo test` before committing.
 
@@ -53,7 +55,9 @@ Always run `cargo fmt` and `cargo test` before committing.
 
 ```
 src/
+  main.rs         # Production binary: CLI, config, logging, frame loop
   lib.rs          # Crate root; enables portable_simd, exports all modules
+  config.rs       # TOML configuration loading + validation
   exg.rs          # SIMD-based Excess Green (ExG) mask computation
   vision.rs       # Adaptive multi-cue vegetation detector (PlantVision)
   lanes.rs        # Lane reduction with hysteresis (LaneReducer)
@@ -151,17 +155,17 @@ This prevents rapid toggling when vegetation coverage hovers near the threshold.
 
 ### ExG SIMD (`exg::exg_mask`)
 
-The standalone `exg_mask` function in `exg.rs` provides a fast single-cue mask using `std::simd`. It processes 16 pixels per iteration using `u8x16`/`i16x16` vectors, with a scalar loop handling the remainder. Note: `PlantVision::detect()` uses its own scalar multi-cue scoring and does not call `exg_mask`.
+The standalone `exg_mask` function in `exg.rs` provides a fast single-cue mask using `std::simd`. It processes 16 pixels (48 interleaved bytes) per iteration: the R/G/B channels are deinterleaved with stride 3 into `u8x16` vectors, widened to `i16x16` for the ExG arithmetic, and a scalar loop handles the remainder. Note: `PlantVision::detect()` uses its own scalar multi-cue scoring and does not call `exg_mask`.
 
 ## Code Conventions
 
 - **Formatting:** Run `cargo fmt` before every commit. CI enforces `cargo fmt --check`.
 - **Documentation:** Use Rustdoc comments (`///`) on public functions and types.
 - **Functions:** Keep small and focused, single responsibility.
-- **Error handling:** Assertions (`assert!`) with descriptive messages for preconditions. No `Result`/`Error` types in the current API — panics on invalid input (appropriate for the embedded use case).
+- **Error handling:** Assertions (`assert!`) with descriptive messages for preconditions in the pipeline hot path. Configuration loading (`Config::load`) and validation (`Config::validate`) return `Result<_, String>` — a bad config file must be a hard startup error, never a silent fallback, because default GPIO pins on miswired hardware could actuate the wrong valves. A *missing* config file still yields defaults so testing stays easy.
 - **Testing:** Unit tests in `#[cfg(test)]` modules within each source file. Panic tests use `#[should_panic(expected = "...")]`.
 - **SIMD:** `exg.rs` uses `std::simd` with `u8x16`/`i16x16` vectors. Scalar fallback handles remainder pixels.
-- **Feature gating:** Hardware-specific code uses `#[cfg(feature = "rpi")]` and target-arch cfg guards.
+- **Feature gating:** Hardware-specific code uses `#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]` — both conditions are required because `rppal` is a target-specific dependency, so `--features rpi` on a desktop host must still compile (falling back to mock GPIO).
 
 ## Dependencies
 
@@ -201,8 +205,8 @@ cargo install --git https://github.com/cross-rs/cross cross --locked
 
 All unit tests live alongside their modules:
 
-- `config.rs`: 3 tests (sane defaults, partial TOML, full round-trip)
-- `exg.rs`: 2 tests (green detection, non-green rejection)
+- `config.rs`: 6 tests (sane defaults, partial TOML, full round-trip, missing file, validation failures)
+- `exg.rs`: 4 tests (green detection, non-green rejection, interleaved SIMD path, SIMD-vs-scalar agreement)
 - `vision.rs`: 3 tests (bright green, dry soil, weight overrides)
 - `lanes.rs`: 5 tests (hysteresis, zero-lanes panic, edge cases)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ VCC    = 5V from Pi (for relay coil logic)
 > lanes. If your relays are active-low, either use a board with
 > optocoupler isolation that accepts active-high, or swap the wiring
 > to use the NC (Normally Closed) terminals instead of NO.
+>
+> All pins are initialised **LOW** at startup and driven LOW again on
+> shutdown, so nozzles stay off whenever the pipeline is not actively
+> spraying.
 
 ## Quick Start (Desktop / Testing)
 
@@ -385,7 +389,7 @@ ls -la /dev/video0
 ## Development
 
 ```bash
-# Run tests (10 unit tests)
+# Run tests (18 unit tests)
 cargo test
 
 # Format code

--- a/deploy/rustspray.service
+++ b/deploy/rustspray.service
@@ -11,7 +11,9 @@ Type=simple
 # to determine camera backend, resolution, and frame rate.
 ExecStart=/bin/sh -c '/usr/local/bin/rustspray-camera | /usr/local/bin/rustspray --config /etc/rustspray/config.toml'
 
-Restart=on-failure
+# Always restart: a camera drop-out makes rustspray exit cleanly on EOF,
+# and the sprayer must come back on its own in the field.
+Restart=always
 RestartSec=5
 
 # GPIO access requires root.
@@ -23,10 +25,12 @@ StandardError=journal
 
 Environment=RUST_LOG=info
 
-# Hardening
+# Hardening. GPIO access goes through /dev/gpiomem* (rppal), which is
+# unaffected by ProtectSystem. Do NOT add ReadWritePaths=/sys/class/gpio —
+# that path no longer exists on Raspberry Pi OS Bookworm and a missing
+# ReadWritePaths entry makes the unit fail to start.
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/sys/class/gpio /sys/devices
 PrivateTmp=true
 NoNewPrivileges=true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,23 +170,55 @@ impl Default for LoggingConfig {
 impl Config {
     /// Load configuration from a TOML file.
     ///
-    /// Returns defaults if the file is missing or unparseable (with a
-    /// warning printed to stderr).
-    pub fn load(path: &Path) -> Self {
+    /// A missing file yields the defaults (with a note on stderr) so the
+    /// binary stays usable for testing. A file that exists but cannot be
+    /// read or parsed is an **error** — silently falling back to default
+    /// GPIO pins on a misconfigured sprayer could actuate the wrong
+    /// hardware.
+    pub fn load(path: &Path) -> Result<Self, String> {
         match std::fs::read_to_string(path) {
-            Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
-                eprintln!(
-                    "Warning: failed to parse {}: {}; using defaults",
-                    path.display(),
-                    e,
-                );
-                Self::default()
-            }),
-            Err(_) => {
-                eprintln!("Config file {} not found, using defaults", path.display(),);
-                Self::default()
+            Ok(content) => toml::from_str(&content)
+                .map_err(|e| format!("failed to parse {}: {}", path.display(), e)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("Config file {} not found, using defaults", path.display());
+                Ok(Self::default())
             }
+            Err(e) => Err(format!("failed to read {}: {}", path.display(), e)),
         }
+    }
+
+    /// Check invariants the pipeline relies on, returning a description
+    /// of the first problem found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.camera.width == 0 || self.camera.height == 0 {
+            return Err("camera.width and camera.height must be non-zero".into());
+        }
+        if self.camera.fps == 0 {
+            return Err("camera.fps must be non-zero".into());
+        }
+        if self.lanes.count == 0 {
+            return Err("lanes.count must be non-zero".into());
+        }
+        if self.camera.width < self.lanes.count {
+            return Err(format!(
+                "camera.width ({}) must be >= lanes.count ({})",
+                self.camera.width, self.lanes.count,
+            ));
+        }
+        if self.lanes.on_threshold < self.lanes.off_threshold {
+            return Err(format!(
+                "lanes.on_threshold ({}) must be >= lanes.off_threshold ({}) for hysteresis",
+                self.lanes.on_threshold, self.lanes.off_threshold,
+            ));
+        }
+        if self.gpio.pins.len() != self.lanes.count {
+            return Err(format!(
+                "gpio.pins has {} entries but lanes.count is {} — one pin per lane required",
+                self.gpio.pins.len(),
+                self.lanes.count,
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -258,5 +290,38 @@ level = "debug"
         assert_eq!(cfg.gpio.pins, vec![5, 6, 13, 19, 26, 21]);
         assert!(cfg.gpio.mock);
         assert_eq!(cfg.logging.level, "debug");
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn missing_file_yields_defaults() {
+        let cfg = Config::load(Path::new("/nonexistent/rustspray-test.toml")).unwrap();
+        assert_eq!(cfg.camera.width, 640);
+    }
+
+    #[test]
+    fn validate_rejects_pin_lane_mismatch() {
+        let cfg: Config = toml::from_str(
+            r#"
+[lanes]
+count = 6
+"#,
+        )
+        .unwrap();
+        // Default has 4 pins but 6 lanes were requested.
+        let err = cfg.validate().unwrap_err();
+        assert!(err.contains("gpio.pins"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_zero_fps() {
+        let cfg: Config = toml::from_str(
+            r#"
+[camera]
+fps = 0
+"#,
+        )
+        .unwrap();
+        assert!(cfg.validate().is_err());
     }
 }

--- a/src/exg.rs
+++ b/src/exg.rs
@@ -16,10 +16,13 @@ pub fn exg_mask(rgb: &[u8], threshold: i16) -> Vec<bool> {
     );
     let mut out = Vec::with_capacity(rgb.len() / 3);
     let mut i = 0;
+    // 16 pixels (48 interleaved bytes) per iteration. The channels must be
+    // deinterleaved with stride 3 before the vector arithmetic.
     while i + 48 <= rgb.len() {
-        let r = u8x16::from_slice(&rgb[i..i + 16]);
-        let g = u8x16::from_slice(&rgb[i + 16..i + 32]);
-        let b = u8x16::from_slice(&rgb[i + 32..i + 48]);
+        let px = &rgb[i..i + 48];
+        let r = u8x16::from_array(std::array::from_fn(|j| px[3 * j]));
+        let g = u8x16::from_array(std::array::from_fn(|j| px[3 * j + 1]));
+        let b = u8x16::from_array(std::array::from_fn(|j| px[3 * j + 2]));
         let r16: i16x16 = r.cast();
         let g16: i16x16 = g.cast();
         let b16: i16x16 = b.cast();
@@ -56,5 +59,45 @@ mod tests {
         let rgb = [120u8, 120u8, 120u8];
         let mask = exg_mask(&rgb, 10);
         assert!(!mask[0]);
+    }
+
+    #[test]
+    fn simd_path_handles_interleaved_pixels() {
+        // 20 pixels exercises the 16-wide SIMD block plus the scalar
+        // remainder. Alternate green / grey pixels so a channel mixup in
+        // the deinterleave shows up immediately.
+        let mut rgb = Vec::new();
+        for i in 0..20 {
+            if i % 2 == 0 {
+                rgb.extend_from_slice(&[10, 240, 10]);
+            } else {
+                rgb.extend_from_slice(&[120, 120, 120]);
+            }
+        }
+        let mask = exg_mask(&rgb, 20);
+        assert_eq!(mask.len(), 20);
+        for (i, &m) in mask.iter().enumerate() {
+            assert_eq!(m, i % 2 == 0, "pixel {i}");
+        }
+    }
+
+    #[test]
+    fn simd_matches_scalar_reference() {
+        // Deterministic varied pattern across many pixels; the SIMD path
+        // must agree with the scalar ExG formula for every one.
+        let mut rgb = Vec::new();
+        for i in 0u32..333 {
+            rgb.push((i * 7 % 256) as u8);
+            rgb.push((i * 13 % 256) as u8);
+            rgb.push((i * 29 % 256) as u8);
+        }
+        let mask = exg_mask(&rgb, 20);
+        assert_eq!(mask.len(), 333);
+        for (p, &m) in mask.iter().enumerate() {
+            let r = rgb[3 * p] as i16;
+            let g = rgb[3 * p + 1] as i16;
+            let b = rgb[3 * p + 2] as i16;
+            assert_eq!(m, 2 * g - r - b > 20, "pixel {p}");
+        }
     }
 }

--- a/src/io_gpio.rs
+++ b/src/io_gpio.rs
@@ -16,29 +16,53 @@ impl NozzleControl for MockGpio {
     }
 }
 
-#[cfg(feature = "rpi")]
+// Real GPIO is only available when the `rpi` feature is enabled AND we are
+// compiling for ARM — `rppal` is a target-specific dependency, so gating on
+// the feature alone would break `--features rpi` builds on desktop hosts.
+#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]
 use rppal::gpio::{Gpio, OutputPin};
 
-#[cfg(feature = "rpi")]
+#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]
 /// GPIO implementation using `rppal`.
+///
+/// All pins are initialised **low** (nozzles off) and are driven low again
+/// when the struct is dropped, so a graceful shutdown never leaves a valve
+/// open.
 pub struct RppalGpio {
     pins: Vec<OutputPin>,
 }
 
-#[cfg(feature = "rpi")]
+#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]
 impl RppalGpio {
     /// Create from BCM pin numbers.
+    ///
+    /// # Panics
+    /// Panics with a descriptive message if the GPIO peripheral or any
+    /// requested pin cannot be acquired.
     pub fn new(pins: &[u8]) -> Self {
-        let gpio = Gpio::new().expect("gpio");
+        let gpio = Gpio::new().expect(
+            "failed to access the GPIO peripheral — is this a Raspberry Pi \
+             and is /dev/gpiomem accessible (root or `gpio` group)?",
+        );
         let pins = pins
             .iter()
-            .map(|&p| gpio.get(p).unwrap().into_output())
+            .map(|&p| {
+                let mut pin = gpio
+                    .get(p)
+                    .unwrap_or_else(|e| panic!("failed to acquire GPIO pin {p}: {e}"))
+                    .into_output_low();
+                // Keep the pin as a low output on drop instead of rppal's
+                // default reset-to-floating-input, which could energise
+                // active-low relay boards.
+                pin.set_reset_on_drop(false);
+                pin
+            })
             .collect();
         Self { pins }
     }
 }
 
-#[cfg(feature = "rpi")]
+#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]
 impl NozzleControl for RppalGpio {
     fn apply(&mut self, lanes: &[bool]) {
         for (pin, &active) in self.pins.iter_mut().zip(lanes) {
@@ -47,6 +71,15 @@ impl NozzleControl for RppalGpio {
             } else {
                 pin.set_low();
             }
+        }
+    }
+}
+
+#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]
+impl Drop for RppalGpio {
+    fn drop(&mut self) {
+        for pin in &mut self.pins {
+            pin.set_low();
         }
     }
 }

--- a/src/lanes.rs
+++ b/src/lanes.rs
@@ -24,6 +24,11 @@ impl LaneReducer {
         }
     }
 
+    /// Number of lanes this reducer produces.
+    pub fn lane_count(&self) -> usize {
+        self.lanes
+    }
+
     /// Reduce the mask given image width/height.
     pub fn reduce(&mut self, mask: &[bool], width: usize, height: usize) -> Vec<bool> {
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 //! or generates synthetic test frames, runs the vegetation detection
 //! pipeline, and drives GPIO pins to control spray nozzles.
 
-use log::{error, info, warn};
+use log::{error, info};
 use rustspray::{
     config::Config,
     io_gpio::{MockGpio, NozzleControl},
@@ -34,12 +34,27 @@ fn main() {
     let config_path = get_arg_value(&args, "--config")
         .or_else(|| get_arg_value(&args, "-c"))
         .unwrap_or_else(|| "/etc/rustspray/config.toml".to_string());
-    let config = Config::load(std::path::Path::new(&config_path));
+    let config = match Config::load(std::path::Path::new(&config_path)) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(2);
+        }
+    };
+    if let Err(e) = config.validate() {
+        eprintln!("Error: invalid configuration: {e}");
+        std::process::exit(2);
+    }
 
-    // Initialise logging.
-    let log_level = get_arg_value(&args, "--log-level").unwrap_or(config.logging.level.clone());
-    std::env::set_var("RUST_LOG", &log_level);
-    env_logger::init();
+    // Initialise logging. Precedence: --log-level flag > RUST_LOG env
+    // > config file.
+    let mut log_builder = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(&config.logging.level),
+    );
+    if let Some(level) = get_arg_value(&args, "--log-level") {
+        log_builder.parse_filters(&level);
+    }
+    log_builder.init();
 
     info!("rustspray {} starting", env!("CARGO_PKG_VERSION"));
     info!(
@@ -120,7 +135,9 @@ fn main() {
         run_stdin(&mut pipeline, frame_size, max_frames, &running);
     }
 
-    info!("shutdown complete");
+    // Fail safe: never exit with a valve left open.
+    pipeline.all_off();
+    info!("all nozzles off — shutdown complete");
 }
 
 // ---------------------------------------------------------------------------
@@ -218,16 +235,18 @@ fn run_stdin(
 // GPIO construction
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "rpi")]
+#[cfg(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64")))]
 fn build_real_gpio(config: &Config) -> Box<dyn NozzleControl> {
     use rustspray::io_gpio::RppalGpio;
     info!("using real GPIO pins: {:?}", config.gpio.pins);
     Box::new(RppalGpio::new(&config.gpio.pins))
 }
 
-#[cfg(not(feature = "rpi"))]
+#[cfg(not(all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64"))))]
 fn build_real_gpio(_config: &Config) -> Box<dyn NozzleControl> {
-    warn!("real GPIO unavailable (not compiled with --features rpi); falling back to mock");
+    log::warn!(
+        "real GPIO unavailable (requires an ARM build with --features rpi); falling back to mock"
+    );
     Box::new(MockGpio::default())
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -40,4 +40,11 @@ impl Pipeline {
         let lanes = self.reducer.reduce(&mask, self.width, self.height);
         self.gpio.apply(&lanes);
     }
+
+    /// Force every nozzle off. Call during shutdown so no valve is left
+    /// open when the process exits.
+    pub fn all_off(&mut self) {
+        let lanes = vec![false; self.reducer.lane_count()];
+        self.gpio.apply(&lanes);
+    }
 }


### PR DESCRIPTION
The exg_mask SIMD path read interleaved RGB bytes as if they were
planar, producing wrong masks for any image of 16+ pixels. The channels
are now deinterleaved with stride 3 before the vector arithmetic, with
new tests covering the SIMD block, the scalar remainder, and
SIMD-vs-scalar agreement across a varied pattern.

Raspberry Pi / hardware-safety fixes:
- Gate RppalGpio on both the rpi feature and ARM target_arch so
  --features rpi compiles on desktop hosts (rppal is a target-specific
  dependency); CI now checks the rpi feature on the host and on both
  aarch64 and armv7 targets
- Initialise GPIO pins low, keep them as low outputs on drop instead of
  rppal's reset-to-floating-input default, and force all nozzles off on
  shutdown via Pipeline::all_off()
- Make config parse/read errors fatal instead of silently falling back
  to default GPIO pins; missing file still yields defaults
- Add Config::validate(): non-zero dimensions/fps/lanes, pins count
  must match lane count, on_threshold >= off_threshold
- Respect RUST_LOG env (flag > env > config) instead of clobbering it
- systemd unit: drop ReadWritePaths=/sys/class/gpio (path is gone on
  Pi OS Bookworm and its absence fails unit startup); Restart=always so
  a camera EOF exit restarts the sprayer in the field
- Remove stale .gitmodules referencing an absent yocto/poky submodule
- Update CLAUDE.md/README to match

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RJzmAt2ofhFCyhZcRSa3VG