### PR TITLE
Fix SIMD bug, harden Raspberry Pi deployment, add OWL host-integration (IPC v1 + FFI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Always run `cargo fmt` and `cargo test` before committing.
 ```
 src/
   main.rs         # Production binary: CLI, config, logging, frame loop
+  watchdog.rs     # Binary-only sd_notify client for the systemd watchdog
   lib.rs          # Crate root; enables portable_simd, exports all modules
   config.rs       # TOML configuration loading + validation
   exg.rs          # SIMD-based Excess Green (ExG) mask computation

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ nozzles across independent lanes — all in real time.
   prevent rapid nozzle toggling near the decision boundary
 - **Configurable** — all thresholds, weights, pin mappings, and camera
   settings live in a single TOML config file
+- **Fail-safe** — nozzles are forced off on shutdown, a stalled camera
+  triggers a safe exit-and-restart, and a systemd watchdog catches a
+  wedged process
 - **Production-ready** — systemd service, install scripts, graceful
   shutdown, and structured logging via the journal
 - **Cross-compile friendly** — build on x86_64, deploy to ARM with one
@@ -196,6 +199,8 @@ device  = "/dev/video0" # Only for V4L2 backend
 width   = 640
 height  = 480
 fps     = 30
+stall_timeout_secs = 10 # Fail safe (exit, nozzles off) if no frame
+                        # arrives for this long; 0 disables
 
 [gpio]
 pins = [17, 27, 22, 23] # BCM pin numbers — must match your wiring

--- a/config/rustspray.toml
+++ b/config/rustspray.toml
@@ -10,6 +10,11 @@ width  = 640
 height = 480
 fps    = 30
 
+# Fail safe if the camera stops delivering frames: exit (nozzles off,
+# systemd restarts the service) after this many seconds without a
+# complete frame. Set to 0 to disable stall detection.
+stall_timeout_secs = 10
+
 # Camera backend used by the helper script:
 #   "v4l2"      — USB camera via ffmpeg + V4L2
 #   "libcamera" — Raspberry Pi Camera Module via rpicam-vid + ffmpeg

--- a/deploy/rustspray.service
+++ b/deploy/rustspray.service
@@ -16,6 +16,15 @@ ExecStart=/bin/sh -c '/usr/local/bin/rustspray-camera | /usr/local/bin/rustspray
 Restart=always
 RestartSec=5
 
+# Watchdog: rustspray sends WATCHDOG=1 once per second while frames are
+# flowing. If the whole pipeline wedges, systemd kills and restarts it.
+# (Camera stalls are already caught faster by camera.stall_timeout_secs
+# in config.toml.)
+WatchdogSec=30
+# The notify datagrams come from rustspray, not from the shell that
+# ExecStart spawns, so accept them from any process in the cgroup.
+NotifyAccess=all
+
 # GPIO access requires root.
 User=root
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,10 @@ pub struct CameraConfig {
     pub height: usize,
     /// Target frames per second.
     pub fps: u32,
+    /// Fail safe if the camera stops delivering frames: exit (nozzles
+    /// off, systemd restarts the service) after this many seconds
+    /// without a complete frame. `0` disables stall detection.
+    pub stall_timeout_secs: u64,
     /// Camera backend for the helper script: `"v4l2"` or `"libcamera"`.
     pub backend: String,
     /// V4L2 device path (used when `backend = "v4l2"`).
@@ -112,6 +116,7 @@ impl Default for CameraConfig {
             width: 640,
             height: 480,
             fps: 30,
+            stall_timeout_secs: 10,
             backend: "v4l2".to_string(),
             device: "/dev/video0".to_string(),
         }
@@ -255,6 +260,7 @@ count = 6
 width = 320
 height = 240
 fps = 15
+stall_timeout_secs = 7
 backend = "libcamera"
 device = "/dev/video1"
 
@@ -283,6 +289,7 @@ level = "debug"
 "#;
         let cfg: Config = toml::from_str(input).unwrap();
         assert_eq!(cfg.camera.width, 320);
+        assert_eq!(cfg.camera.stall_timeout_secs, 7);
         assert_eq!(cfg.camera.backend, "libcamera");
         assert_eq!(cfg.vision.exg_threshold, 30);
         assert!((cfg.vision.weights.bias - 0.05).abs() < f32::EPSILON);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
 //! or generates synthetic test frames, runs the vegetation detection
 //! pipeline, and drives GPIO pins to control spray nozzles.
 
+mod watchdog;
+
 use log::{error, info};
 use rustspray::{
     config::Config,
@@ -16,6 +18,10 @@ use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use watchdog::Watchdog;
+
+/// Exit code when the camera stops delivering frames (stall fail-safe).
+const EXIT_STALLED: i32 = 3;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -109,10 +115,13 @@ fn main() {
 
     let frame_size = w * h * 3;
     let frame_interval = Duration::from_secs_f64(1.0 / config.camera.fps as f64);
+    let stall_timeout = Duration::from_secs(config.camera.stall_timeout_secs);
 
     info!("pipeline ready — frame size {} bytes", frame_size);
 
-    if test_pattern {
+    let mut watchdog = Watchdog::new();
+
+    let stalled = if test_pattern {
         info!("running with test pattern");
         run_test_pattern(
             &mut pipeline,
@@ -122,7 +131,9 @@ fn main() {
             oneshot,
             &running,
             frame_interval,
+            &mut watchdog,
         );
+        false
     } else {
         // Detect whether stdin is a pipe/file or a terminal.
         use std::io::IsTerminal;
@@ -131,19 +142,37 @@ fn main() {
             eprintln!("Pipe camera frames into stdin or use --test-pattern. See --help.");
             std::process::exit(1);
         }
-        info!("reading RGB24 frames from stdin");
-        run_stdin(&mut pipeline, frame_size, max_frames, &running);
-    }
+        info!(
+            "reading RGB24 frames from stdin (stall timeout: {})",
+            if stall_timeout.is_zero() {
+                "disabled".to_string()
+            } else {
+                format!("{} s", stall_timeout.as_secs())
+            },
+        );
+        run_stdin(
+            &mut pipeline,
+            frame_size,
+            max_frames,
+            &running,
+            stall_timeout,
+            &mut watchdog,
+        )
+    };
 
     // Fail safe: never exit with a valve left open.
     pipeline.all_off();
     info!("all nozzles off — shutdown complete");
+    if stalled {
+        std::process::exit(EXIT_STALLED);
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Frame sources
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn run_test_pattern(
     pipeline: &mut Pipeline,
     width: usize,
@@ -152,6 +181,7 @@ fn run_test_pattern(
     oneshot: bool,
     running: &Arc<AtomicBool>,
     interval: Duration,
+    watchdog: &mut Watchdog,
 ) {
     let mut frame = vec![0u8; width * height * 3];
     // Green in lanes 0 and 2 (quarters 1 and 3), soil elsewhere.
@@ -175,6 +205,7 @@ fn run_test_pattern(
         let start = Instant::now();
         pipeline.process(&frame);
         count += 1;
+        watchdog.ping();
 
         let elapsed = start.elapsed();
         if count % 100 == 0 || count == 1 {
@@ -192,43 +223,93 @@ fn run_test_pattern(
     info!("processed {} frames", count);
 }
 
+/// Read frames from stdin on a dedicated thread and process them here.
+///
+/// Blocking `read_exact` on the main thread cannot detect a camera that
+/// hangs *without* closing the pipe — the process would sit forever with
+/// the last lane state applied to the valves. The reader thread plus a
+/// polled channel lets the main loop notice missing frames and fail safe.
+///
+/// Returns `true` if the loop ended because the camera stalled.
 fn run_stdin(
     pipeline: &mut Pipeline,
     frame_size: usize,
     max_frames: u64,
     running: &Arc<AtomicBool>,
-) {
-    let mut stdin = std::io::stdin().lock();
-    let mut buf = vec![0u8; frame_size];
+    stall_timeout: Duration,
+    watchdog: &mut Watchdog,
+) -> bool {
+    use crossbeam::channel::{bounded, RecvTimeoutError};
+
+    let (frame_tx, frame_rx) = bounded::<Vec<u8>>(1);
+    // Recycle buffers back to the reader to keep the hot path allocation-free.
+    let (free_tx, free_rx) = bounded::<Vec<u8>>(2);
+    for _ in 0..2 {
+        let _ = free_tx.try_send(vec![0u8; frame_size]);
+    }
+
+    std::thread::spawn(move || {
+        let mut stdin = std::io::stdin().lock();
+        loop {
+            let mut buf = free_rx.try_recv().unwrap_or_else(|_| vec![0u8; frame_size]);
+            match stdin.read_exact(&mut buf) {
+                Ok(()) => {
+                    if frame_tx.send(buf).is_err() {
+                        break; // main loop is gone
+                    }
+                }
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                        info!("end of input stream");
+                    } else {
+                        error!("stdin read error: {}", e);
+                    }
+                    break; // dropping frame_tx disconnects the channel
+                }
+            }
+        }
+    });
+
+    // Poll in short intervals so SIGINT/SIGTERM stays responsive while
+    // waiting for frames.
+    let poll = Duration::from_millis(200);
+    let mut last_frame = Instant::now();
     let mut count: u64 = 0;
 
     while running.load(Ordering::SeqCst) {
-        match stdin.read_exact(&mut buf) {
-            Ok(()) => {}
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::UnexpectedEof {
-                    info!("end of input stream");
-                } else {
-                    error!("stdin read error: {}", e);
+        match frame_rx.recv_timeout(poll) {
+            Ok(buf) => {
+                let start = Instant::now();
+                pipeline.process(&buf);
+                let _ = free_tx.try_send(buf);
+                count += 1;
+                last_frame = Instant::now();
+                watchdog.ping();
+
+                let elapsed = start.elapsed();
+                if count % 100 == 0 || count == 1 {
+                    info!("frame {}: {:.1} ms", count, elapsed.as_secs_f64() * 1000.0,);
                 }
-                break;
+
+                if max_frames > 0 && count >= max_frames {
+                    break;
+                }
             }
-        }
-
-        let start = Instant::now();
-        pipeline.process(&buf);
-        count += 1;
-
-        let elapsed = start.elapsed();
-        if count % 100 == 0 || count == 1 {
-            info!("frame {}: {:.1} ms", count, elapsed.as_secs_f64() * 1000.0,);
-        }
-
-        if max_frames > 0 && count >= max_frames {
-            break;
+            Err(RecvTimeoutError::Timeout) => {
+                if !stall_timeout.is_zero() && last_frame.elapsed() >= stall_timeout {
+                    error!(
+                        "no frame received for {} s — camera stalled, failing safe",
+                        stall_timeout.as_secs(),
+                    );
+                    info!("processed {} frames", count);
+                    return true;
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => break,
         }
     }
     info!("processed {} frames", count);
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,78 @@
+//! Minimal systemd watchdog client (binary-only module).
+//!
+//! Implements just enough of the `sd_notify` protocol to send `READY=1`
+//! at startup and throttled `WATCHDOG=1` pings from the frame loop, so a
+//! wedged process is killed and restarted by systemd (`WatchdogSec=`).
+//! Everything no-ops when not running under systemd (`NOTIFY_SOCKET`
+//! unset), so desktop and manual runs are unaffected.
+
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::net::UnixDatagram;
+
+/// Sends watchdog keep-alives to systemd's notify socket.
+pub struct Watchdog {
+    #[cfg(unix)]
+    socket: Option<UnixDatagram>,
+    last_ping: Instant,
+}
+
+impl Watchdog {
+    /// Connect to `$NOTIFY_SOCKET` if present and announce `READY=1`.
+    pub fn new() -> Self {
+        let mut wd = Self {
+            #[cfg(unix)]
+            socket: connect_notify_socket(),
+            last_ping: Instant::now(),
+        };
+        #[cfg(unix)]
+        if wd.socket.is_some() {
+            log::info!("systemd watchdog notifications enabled");
+        }
+        wd.send("READY=1");
+        wd
+    }
+
+    /// Call once per processed frame; sends `WATCHDOG=1` at most once
+    /// per second.
+    pub fn ping(&mut self) {
+        if self.last_ping.elapsed() >= Duration::from_secs(1) {
+            self.send("WATCHDOG=1");
+            self.last_ping = Instant::now();
+        }
+    }
+
+    #[cfg(unix)]
+    fn send(&self, msg: &str) {
+        if let Some(sock) = &self.socket {
+            let _ = sock.send(msg.as_bytes());
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn send(&self, _msg: &str) {}
+}
+
+#[cfg(unix)]
+fn connect_notify_socket() -> Option<UnixDatagram> {
+    let path = std::env::var("NOTIFY_SOCKET").ok()?;
+    let sock = UnixDatagram::unbound().ok()?;
+    if let Some(name) = path.strip_prefix('@') {
+        // Abstract-namespace socket (containers, portable services).
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::linux::net::SocketAddrExt;
+            let addr = std::os::unix::net::SocketAddr::from_abstract_name(name.as_bytes()).ok()?;
+            sock.connect_addr(&addr).ok()?;
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = name;
+            return None;
+        }
+    } else {
+        sock.connect(&path).ok()?;
+    }
+    Some(sock)
+}


### PR DESCRIPTION
## Summary

Three rounds of work on one branch:

1. **Full program review + Pi hardening** — one real correctness bug plus deployment blockers
2. **Camera stall fail-safe + systemd watchdog**
3. **Host-integration surfaces** so Rust-Spray can run as the detection + actuation inner loop inside OpenWeedLocator (Rust side only; the OWL Python wrapper is separate work in that repo)

### Correctness: `exg_mask` SIMD path computed wrong masks

`src/exg.rs` loaded `rgb[i..i+16]` as 16 red values, but frames are **interleaved** RGB — the SIMD path mixed channels across pixels and returned wrong results for any image of 16+ pixels. Existing tests only fed it 3 bytes (scalar path). Now deinterleaved with stride 3, with tests covering the SIMD block, scalar remainder, and SIMD-vs-scalar agreement.

### Raspberry Pi build was untested and broken off-ARM

- GPIO code gated on `all(feature = "rpi", any(target_arch = "arm", target_arch = "aarch64"))` so `--features rpi` compiles everywhere (`rppal` is target-specific); mock fallback on desktop.
- CI now checks the `rpi` feature on the host and on `aarch64-unknown-linux-gnu` + `armv7-unknown-linux-gnueabihf`, plus `cargo clippy --all-targets -- -D warnings`.
- New `release.yml`: on every `v*` tag, cross-compiles and attaches `rustspray-aarch64` (Pi 4/5) and `rustspray-armv7` (Pi 3B+) to the GitHub release.

### Hardware safety

- GPIO pins initialise **low**, stay low outputs on drop (instead of rppal's reset-to-floating-input), and every exit path forces all nozzles off.
- Config parse errors are fatal at startup (no silent fallback to default pins); `Config::validate()` catches pin/lane mismatches, zero fps/dimensions, inverted hysteresis.
- **Camera stall fail-safe**: frames are read on a dedicated thread; no frame for `camera.stall_timeout_secs` (default 10 s) → nozzles off, exit 3, systemd restarts.
- **systemd watchdog**: minimal `sd_notify` client (no new deps) sends `READY=1` + throttled `WATCHDOG=1`; unit sets `WatchdogSec=30` / `NotifyAccess=all`.

### systemd unit fixes

- Removed `ReadWritePaths=/sys/class/gpio` (gone on Pi OS Bookworm; its absence fails unit startup).
- `Restart=always` so a camera EOF exit restarts the sprayer in the field.

### Host integration (OpenWeedLocator inner loop)

- **`--ipc-mode`** (`src/ipc.rs`): per-frame `[u32 width LE][u32 height LE]` header + RGB24 payload on stdin; one flushed NDJSON object per frame on stdout: `{"v":1,"frame":N,"ts_us":…,"lanes":[…],"latency_us":…}`. First frame fixes dimensions; mid-stream changes and truncation are fatal; dims capped at 4096. GPIO drives as normal; same stall fail-safe and nozzles-off guarantees. Exit codes: 0 clean EOF/signal, 1 protocol error, 2 config error, 3 stall.
- **`--output-version`**: `{"rustspray_version":"0.3.0","ipc_protocol":1}` startup handshake for hosts.
- **C FFI** (`src/ffi.rs`, `librustspray_core.so` via new `[lib]` cdylib+rlib target `rustspray_core`): `rustspray_detect(rgb24, w, h, config_path, lane_states, num_lanes)` → 0 or negative errno; panics caught at the boundary. Stateless v1 (no hysteresis/GPIO) — documented.
- **`MockGpio`** now prints state *changes* to stderr as `[MOCK GPIO] lane=N state=ON/OFF` so stdout stays clean for the protocol stream.
- **`INTEGRATION.md`**: versioned contract — protocol history, byte layout, JSON schema, handshake, error behaviour/exit codes, `NozzleControl` backend guide (CAN/ISOBUS/serial), build targets, Python examples.
- Version bumped to 0.3.0; release profile adds thin LTO + strip.

Deviation from the integration spec: kept the existing hand-rolled arg parsing instead of adding `clap`, matching the codebase's minimal-dependency convention.

## Test plan

- [x] 32 tests pass: 28 unit (incl. 6 IPC protocol, 4 FFI) + 4 end-to-end tests spawning the real binary in `--ipc-mode` over pipes
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo check` for `camera-nokhwa`, `camera-gstreamer`, `rpi` (host + aarch64 + armv7)
- [x] Live stall test: silent open pipe → fail-safe exit 3 with nozzles off; fake `NOTIFY_SOCKET` receives `READY=1`/`WATCHDOG=1`
- [x] Python smoke test (OWL-style): handshake, 50-frame 640×480 IPC session at ~1.5 ms median latency, ctypes call into `librustspray_core.so`
- [ ] Validate on real Pi hardware: `./scripts/deploy.sh pi@<host>`, camera pipe, relays, service restart on camera unplug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJzmAt2ofhFCyhZcRSa3VG